### PR TITLE
docs: enhance CONTRIBUTING.md and fix Steward references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,138 @@
-# Contributing
+# Contributing to Butler Bootstrap
 
-Contributing to this project in any way legally acknowledges acceptance by the contributor of the terms outlined in the Developer Certificate of Origin in the DCO file.
+Thank you for your interest in contributing to Butler Bootstrap!
 
-Any merge request, issue posts, commit, or any other content development on this project legally constitutes signed acceptance of the terms in the DCO, meaning that any contribution to this project in any way releases any legal claim on those contributions including copyright, patents, trademarks, and any other intellectual property rights. It is the responsibility of all would-be contributors to legally ensure that they indeed have those rights themselves to release in the first place (and that those that employ them agree).
+## Development Setup
 
-Developers sometimes do not realize that at the moment of their employment they may have signed away their rights to contribute to such projects without explicit (often written) permission from their employer. Doing so can result in immediate termination when discovered. Notwithstanding such violations, in such unfortunate cases, any contribution remains as a donation and newly acquired intellectual property of the project owners. This project, its owners, and other contributors shall be legally indemnified when unapproved contributions are made. Any conflict or litigation must only be between the contributor who violated the terms of their employment and their employer.
+### Prerequisites
+
+- Go 1.24+
+- Docker
+- kubectl
+- make
+- Access to a Kubernetes cluster (for integration testing)
+
+### Building
+
+```bash
+# Build binary
+make build
+
+# Build container image
+make docker-build IMG=ghcr.io/butlerdotdev/butler-bootstrap:dev
+```
+
+### Running Locally
+
+```bash
+# Run controller locally against your kubeconfig
+make run
+```
+
+### Running Tests
+
+```bash
+# Unit tests
+make test
+
+# Linting
+make lint
+
+# All checks
+make test && make lint
+```
+
+## Code Guidelines
+
+### Project Structure
+
+- `cmd/main.go` - Controller manager entry point
+- `internal/controller/` - Reconciliation logic
+- `internal/addons/` - Helm-based addon installation
+- `internal/talos/` - Talos API client wrapper
+- `internal/crds/` - Embedded CRD YAML for self-registration
+
+### Bootstrap Phases
+
+The controller drives ClusterBootstrap through these phases:
+
+```
+Pending → ProvisioningMachines → ConfiguringTalos → BootstrappingCluster → InstallingAddons → Pivoting → Ready
+```
+
+Each phase has specific responsibilities:
+- **ProvisioningMachines**: Creates MachineRequest CRDs, waits for VMs
+- **ConfiguringTalos**: Generates and applies Talos configs
+- **BootstrappingCluster**: Bootstraps first control plane, retrieves kubeconfig
+- **InstallingAddons**: Installs platform components in dependency order
+- **Pivoting**: Makes cluster self-managing (HA only)
+- **Ready**: Bootstrap complete
+
+### Adding a New Addon
+
+1. Add installation method to `AddonInstallerInterface` in `internal/addons/installer.go`
+2. Implement the method with Helm SDK
+3. Add to the installation order in the controller
+4. Update documentation
+
+### Testing
+
+The controller uses `envtest` for unit testing. Key interfaces (`TalosClientInterface`, `AddonInstallerInterface`) are designed for mocking.
+
+```go
+// Example test with mock
+func TestReconcile_ConfiguringTalos(t *testing.T) {
+    mockTalos := &mocks.MockTalosClient{}
+    mockTalos.On("GenerateConfig", mock.Anything, mock.Anything).Return(&talos.TalosConfigs{}, nil)
+
+    reconciler := &ClusterBootstrapReconciler{
+        TalosClient: mockTalos,
+    }
+    // ...
+}
+```
+
+### Key Conventions
+
+- Requeue intervals: `requeueShort` (5s) for active operations, `requeueMedium` (15s) for waiting
+- Use finalizers for cleanup: `clusterbootstrap.butler.butlerlabs.dev/finalizer`
+- Status conditions follow K8s conventions: `Ready`, `Progressing`, `Failed`
+- Talos configs stored in Secrets in the ClusterBootstrap namespace
+
+## Pull Request Process
+
+1. Fork the repository
+2. Create a feature branch from `main`
+3. Make your changes
+4. Run tests and linting: `make test && make lint`
+5. Commit with conventional commit messages
+6. Push to your fork and open a PR
+
+### Commit Message Format
+
+```
+type(scope): description
+
+[optional body]
+
+[optional footer]
+```
+
+Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
+
+Examples:
+- `feat(addons): add external-dns installation`
+- `fix(talos): handle config apply timeout`
+- `docs: update bootstrap phase documentation`
+
+## Developer Certificate of Origin
+
+By contributing to this project, you agree to the Developer Certificate of Origin (DCO). This means you certify that you wrote the contribution or have the right to submit it under the project's license.
+
+Sign off your commits with `git commit -s` or add `Signed-off-by: Your Name <your.email@example.com>` to your commit messages.
+
+Any merge request, issue posts, commit, or any other content development on this project legally constitutes signed acceptance of the terms in the DCO, meaning that any contribution to this project in any way releases any legal claim on those contributions including copyright, patents, trademarks, and any other intellectual property rights.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the Apache License 2.0.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ flowchart TD
     
     subgraph MC[Management Cluster - Permanent]
         CAPI[Cluster API]
-        Kamaji[Kamaji]
+        Steward[Steward]
         Cilium[Cilium]
         Longhorn[Longhorn]
         MetalLB[MetalLB]
@@ -127,7 +127,7 @@ The controller installs addons in a specific order to satisfy dependencies:
 4. Longhorn (distributed storage)
 5. MetalLB (LoadBalancer services)
 6. Traefik (ingress controller)
-7. Kamaji (hosted control planes)
+7. Steward (hosted control planes)
 8. Cluster API (cluster lifecycle management)
 9. Flux (GitOps, optional)
 10. butler-controller (tenant cluster management)


### PR DESCRIPTION
## Summary

- Replace basic DCO-only CONTRIBUTING.md with comprehensive development guide including bootstrap phases, testing patterns, and conventions
- Fix Kamaji references to Steward in architecture diagram and addon installation order

## Test plan

- [ ] Verify CONTRIBUTING.md renders correctly on GitHub
- [ ] Verify mermaid diagram renders with correct "Steward" label
- [ ] Verify addon installation order list shows "Steward" not "Kamaji"