### PR TITLE
feat: enable Cilium Gateway API when exposure mode is Gateway

### DIFF
--- a/internal/addons/installer.go
+++ b/internal/addons/installer.go
@@ -357,7 +357,7 @@ spec:
 }
 
 // InstallCilium installs Cilium CNI
-func (i *Installer) InstallCilium(ctx context.Context, kubeconfig []byte, version string, hubbleEnabled bool) error {
+func (i *Installer) InstallCilium(ctx context.Context, kubeconfig []byte, version string, hubbleEnabled bool, gatewayAPIEnabled bool) error {
 	logger := log.FromContext(ctx)
 	kubeconfigPath, cleanup, err := i.writeKubeconfig(kubeconfig)
 	if err != nil {
@@ -400,6 +400,12 @@ func (i *Installer) InstallCilium(ctx context.Context, kubeconfig []byte, versio
 		args = append(args,
 			"--set", "hubble.relay.enabled=true",
 			"--set", "hubble.ui.enabled=true",
+		)
+	}
+
+	if gatewayAPIEnabled {
+		args = append(args,
+			"--set", "gatewayAPI.enabled=true",
 		)
 	}
 
@@ -640,7 +646,7 @@ func (i *Installer) InstallGatewayAPI(ctx context.Context, kubeconfig []byte, ve
 	defer cleanup()
 
 	if version == "" {
-		version = "v1.2.0"
+		version = "v1.2.1"
 	}
 
 	logger.Info("Installing Gateway API CRDs", "version", version)

--- a/internal/controller/clusterbootstrap_controller.go
+++ b/internal/controller/clusterbootstrap_controller.go
@@ -95,7 +95,7 @@ type TalosConfigs struct {
 type AddonInstallerInterface interface {
 	SetNodeIP(ip string)
 	InstallKubeVip(ctx context.Context, kubeconfig []byte, vip string, iface string, version string) error
-	InstallCilium(ctx context.Context, kubeconfig []byte, version string, hubbleEnabled bool) error
+	InstallCilium(ctx context.Context, kubeconfig []byte, version string, hubbleEnabled bool, gatewayAPIEnabled bool) error
 	InstallCertManager(ctx context.Context, kubeconfig []byte, version string) error
 	InstallLonghorn(ctx context.Context, kubeconfig []byte, version string, replicaCount int32) error
 	InstallMetalLB(ctx context.Context, kubeconfig []byte, addressPool string, topology string) error
@@ -712,8 +712,10 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 			logger.Info("Installing Cilium")
 			version := addons.CNI.Version
 			hubble := addons.CNI.HubbleEnabled
+			gatewayAPI := cb.Spec.ControlPlaneExposure != nil &&
+				cb.Spec.ControlPlaneExposure.Mode == butlerv1alpha1.ControlPlaneExposureModeGateway
 
-			if err := r.AddonInstaller.InstallCilium(ctx, kubeconfig, version, hubble); err != nil {
+			if err := r.AddonInstaller.InstallCilium(ctx, kubeconfig, version, hubble, gatewayAPI); err != nil {
 				logger.Error(err, "Failed to install Cilium")
 				return ctrl.Result{RequeueAfter: requeueShort}, nil
 			}


### PR DESCRIPTION
## Summary

- Add `gatewayAPIEnabled` parameter to `InstallCilium()` that passes `--set gatewayAPI.enabled=true` to the Helm install
- Update `AddonInstallerInterface` to match new signature
- Pass Gateway mode check from `ClusterBootstrap.Spec.ControlPlaneExposure` to the Cilium installer
- Bump Gateway API CRD default version from v1.2.0 to v1.2.1

Without `gatewayAPI.enabled=true`, Cilium won't register a GatewayClass or act as a Gateway API controller.

## Test plan

- [x] Verified Cilium with `gatewayAPI.enabled=true` registers GatewayClass on butler-beta
- [x] Gateway resource created and programmed by Cilium controller
- [x] TLSRoutes accepted by Cilium Gateway listeners
- [x] Full end-to-end tenant provisioning works through Cilium Gateway