### PR TITLE
fix: use ubuntu-latest for multi-arch image builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: make build
 
   image:
-    runs-on: butler-runners
+    runs-on: ubuntu-latest
     needs: build
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
     permissions:


### PR DESCRIPTION
## Summary
- Move `image` CI job from `butler-runners` to `ubuntu-latest` — self-hosted Talos runners lack `binfmt_misc` kernel module needed by `docker/setup-qemu-action` for cross-platform builds

## Test plan
- [ ] CI image job runs on ubuntu-latest and completes successfully
- [ ] Multi-arch image (amd64 + arm64) pushed to GHCR