### PR TITLE
chore: remove CODE_OF_CONDUCT.md stub, inherit from org

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,0 @@
-# Community Code of Conduct
-
-Butler follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).


### PR DESCRIPTION
Remove CODE_OF_CONDUCT.md (3-line stub). Now inherited from the org-level .github repo with full CNCF CoC including enforcement details.

See butlerdotdev/.github#1