### PR TITLE
feat: cloud-aware bootstrap controller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,22 @@ RUN apk add --no-cache git make
 ARG TARGETOS
 ARG TARGETARCH
 
-COPY go.mod go.sum ./
+# REPO_DIR: set to subdirectory name when building with parent context
+# (e.g., REPO_DIR=butler-bootstrap when context is the repo root).
+# Defaults to "." for standard builds where context is the repo itself.
+ARG REPO_DIR=.
+
+COPY ${REPO_DIR}/go.mod ${REPO_DIR}/go.sum ./
+
+# go.mod has: replace github.com/butlerdotdev/butler-api => ../butler-api
+# Copy butler-api module source so the replace directive resolves.
+# /workspace is our WORKDIR, so ../butler-api resolves to /butler-api.
+COPY butler-api/go.mod butler-api/go.sum /butler-api/
+COPY butler-api/api/ /butler-api/api/
+
 RUN go mod download
 
-COPY . .
+COPY ${REPO_DIR}/ .
 
 RUN CGO_ENABLED=0 \
     GOOS=${TARGETOS} \

--- a/internal/addons/installer.go
+++ b/internal/addons/installer.go
@@ -83,7 +83,8 @@ type ProxmoxCredentials struct {
 	Password string
 }
 
-// GCPCredentials holds GCP credentials
+// GCPCredentials contains GCP service account and infrastructure config
+// extracted from a ProviderConfig for use during bootstrap.
 type GCPCredentials struct {
 	ServiceAccountKey string // JSON service account key
 	ProjectID         string
@@ -96,7 +97,8 @@ type GCPCredentials struct {
 	ImageFamily       string
 }
 
-// AWSCredentials holds AWS credentials for EC2 provisioning.
+// AWSCredentials contains IAM credentials and VPC config
+// extracted from a ProviderConfig for use during bootstrap.
 type AWSCredentials struct {
 	AccessKeyID     string
 	SecretAccessKey  string
@@ -106,7 +108,8 @@ type AWSCredentials struct {
 	SecurityGroupID  string
 }
 
-// AzureCredentials holds Azure credentials for VM provisioning.
+// AzureCredentials contains service principal credentials and resource group config
+// extracted from a ProviderConfig for use during bootstrap.
 type AzureCredentials struct {
 	ClientID       string
 	ClientSecret   string
@@ -1344,6 +1347,8 @@ spec:
 	return secretManifest, providerConfigManifest
 }
 
+// generateGCPProviderConfig returns the Secret and ProviderConfig manifests
+// for a GCP provider on the target management cluster.
 func (i *Installer) generateGCPProviderConfig(creds *GCPCredentials) (string, string) {
 	secretManifest := fmt.Sprintf(`apiVersion: v1
 kind: Secret
@@ -1401,6 +1406,8 @@ spec:
 	return secretManifest, providerConfigManifest
 }
 
+// generateAWSProviderConfig returns the Secret and ProviderConfig manifests
+// for an AWS provider on the target management cluster.
 func (i *Installer) generateAWSProviderConfig(creds *AWSCredentials) (string, string) {
 	secretManifest := fmt.Sprintf(`apiVersion: v1
 kind: Secret
@@ -1447,6 +1454,8 @@ spec:
 	return secretManifest, providerConfigManifest
 }
 
+// generateAzureProviderConfig returns the Secret and ProviderConfig manifests
+// for an Azure provider on the target management cluster.
 func (i *Installer) generateAzureProviderConfig(creds *AzureCredentials) (string, string) {
 	secretManifest := fmt.Sprintf(`apiVersion: v1
 kind: Secret

--- a/internal/addons/installer.go
+++ b/internal/addons/installer.go
@@ -628,6 +628,53 @@ spec:
 	return i.runKubectl(ctx, kubeconfigPath, "apply", "-f", tmpFile.Name())
 }
 
+// InstallCloudControllerManager installs the cloud-specific CCM via Helm.
+// CCM is required for LoadBalancer services to get external IPs on cloud providers.
+func (i *Installer) InstallCloudControllerManager(ctx context.Context, kubeconfig []byte, provider string) error {
+	logger := log.FromContext(ctx)
+	kubeconfigPath, cleanup, err := i.writeKubeconfig(kubeconfig)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	logger.Info("Installing Cloud Controller Manager", "provider", provider)
+	i.ensurePrivilegedNamespace(ctx, kubeconfigPath, "kube-system")
+
+	switch provider {
+	case "gcp":
+		_ = i.runHelm(ctx, kubeconfigPath, "repo", "add", "cloud-provider-gcp",
+			"https://kubernetes-sigs.github.io/cloud-provider-gcp")
+		_ = i.runHelm(ctx, kubeconfigPath, "repo", "update")
+		return i.runHelm(ctx, kubeconfigPath,
+			"upgrade", "--install", "cloud-controller-manager",
+			"cloud-provider-gcp/cloud-provider-gcp",
+			"--namespace", "kube-system",
+			"--wait", "--timeout", "5m")
+	case "aws":
+		_ = i.runHelm(ctx, kubeconfigPath, "repo", "add", "aws-cloud-controller-manager",
+			"https://kubernetes.github.io/cloud-provider-aws")
+		_ = i.runHelm(ctx, kubeconfigPath, "repo", "update")
+		return i.runHelm(ctx, kubeconfigPath,
+			"upgrade", "--install", "aws-cloud-controller-manager",
+			"aws-cloud-controller-manager/aws-cloud-controller-manager",
+			"--namespace", "kube-system",
+			"--wait", "--timeout", "5m")
+	case "azure":
+		_ = i.runHelm(ctx, kubeconfigPath, "repo", "add", "cloud-provider-azure",
+			"https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo")
+		_ = i.runHelm(ctx, kubeconfigPath, "repo", "update")
+		return i.runHelm(ctx, kubeconfigPath,
+			"upgrade", "--install", "cloud-controller-manager",
+			"cloud-provider-azure/cloud-controller-manager",
+			"--namespace", "kube-system",
+			"--wait", "--timeout", "5m")
+	default:
+		logger.Info("No CCM needed for provider", "provider", provider)
+		return nil
+	}
+}
+
 // InstallTraefik installs Traefik ingress controller
 func (i *Installer) InstallTraefik(ctx context.Context, kubeconfig []byte, version string) error {
 	logger := log.FromContext(ctx)

--- a/internal/addons/installer.go
+++ b/internal/addons/installer.go
@@ -1548,12 +1548,18 @@ func (i *Installer) InstallCAPI(ctx context.Context, kubeconfig []byte, version 
 		return fmt.Errorf("failed to install Steward CAPI provider: %w", err)
 	}
 	// Install infrastructure provider manually with credentials.
-	// Non-fatal: CAPI infra providers (CAPG, CAPA, CAPZ) have webhook CRDs with
-	// placeholder caBundle that cert-manager's ca-injector must populate. If the
-	// CA hasn't propagated yet, kubectl apply rejects the invalid PEM. The
-	// provider can be installed post-bootstrap; core + capi-steward are sufficient.
+	// Cloud providers (gcp, aws, azure): Non-fatal. CAPI infra providers (CAPG, CAPA, CAPZ)
+	// have webhook CRDs with placeholder caBundle that cert-manager's ca-injector must populate.
+	// If the CA hasn't propagated yet, kubectl apply rejects the invalid PEM. The provider can
+	// be installed post-bootstrap; core + capi-steward are sufficient.
+	// On-prem providers (harvester, nutanix, proxmox): Fatal. These providers don't have the
+	// cert-manager webhook dependency issue and must succeed for bootstrap to proceed.
 	if err := i.installInfraProvider(ctx, kubeconfigPath, mgmtProvider, creds); err != nil {
-		logger.Info("Infrastructure provider install failed (non-fatal, can be installed post-bootstrap)", "provider", mgmtProvider, "error", err)
+		if isCloudProvider(mgmtProvider) {
+			logger.Info("Infrastructure provider install failed (non-fatal for cloud provider, can be installed post-bootstrap)", "provider", mgmtProvider, "error", err)
+		} else {
+			return fmt.Errorf("infrastructure provider install failed for on-prem provider %s: %w", mgmtProvider, err)
+		}
 	}
 
 	// Install any additional providers
@@ -1586,6 +1592,15 @@ func (i *Installer) InstallCAPI(ctx context.Context, kubeconfig []byte, version 
 }
 
 // installInfraProvider installs a CAPI infrastructure provider
+// isCloudProvider returns true for cloud providers (gcp, aws, azure).
+func isCloudProvider(provider string) bool {
+	switch provider {
+	case "gcp", "aws", "azure":
+		return true
+	}
+	return false
+}
+
 func (i *Installer) installInfraProvider(ctx context.Context, kubeconfigPath string, provider string, creds *ProviderCredentials) error {
 	logger := log.FromContext(ctx)
 
@@ -1728,11 +1743,13 @@ func (i *Installer) substituteGCPVariables(manifest string, creds *GCPCredential
 // substituteDefaults replaces remaining ${VAR:=default} patterns with their default values.
 // This handles shell-style variable substitution patterns commonly found in CAPI manifests.
 func substituteDefaults(manifest string) string {
-	for {
-		idx := strings.Index(manifest, "${")
+	offset := 0
+	for offset < len(manifest) {
+		idx := strings.Index(manifest[offset:], "${")
 		if idx == -1 {
 			break
 		}
+		idx += offset
 		end := strings.Index(manifest[idx:], "}")
 		if end == -1 {
 			break
@@ -1743,10 +1760,11 @@ func substituteDefaults(manifest string) string {
 		if colonIdx := strings.Index(expr, ":="); colonIdx != -1 {
 			defaultVal := expr[colonIdx+2:]
 			manifest = manifest[:idx] + defaultVal + manifest[end+1:]
+			// Don't advance offset -- replacement may be shorter, rescan from same position
 			continue
 		}
-		// Skip patterns we don't understand (move past to avoid infinite loop)
-		break
+		// Skip patterns we don't understand (advance past closing brace)
+		offset = end + 1
 	}
 	return manifest
 }

--- a/internal/addons/installer.go
+++ b/internal/addons/installer.go
@@ -43,6 +43,8 @@ type ProviderCredentials struct {
 	VSphere   *VSphereCredentials
 	Proxmox   *ProxmoxCredentials
 	GCP       *GCPCredentials
+	AWS       *AWSCredentials
+	Azure     *AzureCredentials
 }
 
 // NutanixCredentials holds Nutanix Prism Central credentials
@@ -91,6 +93,28 @@ type GCPCredentials struct {
 	MachineType       string
 	ImageProject      string
 	ImageFamily       string
+}
+
+// AWSCredentials holds AWS credentials for EC2 provisioning.
+type AWSCredentials struct {
+	AccessKeyID     string
+	SecretAccessKey  string
+	Region           string
+	VPCID            string
+	SubnetID         string
+	SecurityGroupID  string
+}
+
+// AzureCredentials holds Azure credentials for VM provisioning.
+type AzureCredentials struct {
+	ClientID       string
+	ClientSecret   string
+	TenantID       string
+	SubscriptionID string
+	ResourceGroup  string
+	Location       string
+	VNetName       string
+	SubnetName     string
 }
 
 // NewInstaller creates a new addon installer
@@ -987,6 +1011,16 @@ func (i *Installer) InstallInitialProviderConfig(ctx context.Context, kubeconfig
 			return fmt.Errorf("gcp credentials required")
 		}
 		secretManifest, providerConfigManifest = i.generateGCPProviderConfig(creds.GCP)
+	case "aws":
+		if creds == nil || creds.AWS == nil {
+			return fmt.Errorf("aws credentials required")
+		}
+		secretManifest, providerConfigManifest = i.generateAWSProviderConfig(creds.AWS)
+	case "azure":
+		if creds == nil || creds.Azure == nil {
+			return fmt.Errorf("azure credentials required")
+		}
+		secretManifest, providerConfigManifest = i.generateAzureProviderConfig(creds.Azure)
 	default:
 		logger.Info("Provider type not yet supported for ProviderConfig creation, skipping", "provider", providerType)
 		return nil
@@ -1267,6 +1301,99 @@ spec:
 	return secretManifest, providerConfigManifest
 }
 
+func (i *Installer) generateAWSProviderConfig(creds *AWSCredentials) (string, string) {
+	secretManifest := fmt.Sprintf(`apiVersion: v1
+kind: Secret
+metadata:
+  name: aws-credentials
+  namespace: butler-system
+type: Opaque
+stringData:
+  accessKeyID: "%s"
+  secretAccessKey: "%s"
+`, creds.AccessKeyID, creds.SecretAccessKey)
+
+	awsConfig := fmt.Sprintf(`    region: "%s"`, creds.Region)
+
+	if creds.VPCID != "" {
+		awsConfig += fmt.Sprintf(`
+    vpcID: "%s"`, creds.VPCID)
+	}
+	if creds.SubnetID != "" {
+		awsConfig += fmt.Sprintf(`
+    subnetIDs:
+    - "%s"`, creds.SubnetID)
+	}
+	if creds.SecurityGroupID != "" {
+		awsConfig += fmt.Sprintf(`
+    securityGroupIDs:
+    - "%s"`, creds.SecurityGroupID)
+	}
+
+	providerConfigManifest := fmt.Sprintf(`apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: aws
+  namespace: butler-system
+spec:
+  provider: aws
+  credentialsRef:
+    name: aws-credentials
+    namespace: butler-system
+  aws:
+%s
+`, awsConfig)
+
+	return secretManifest, providerConfigManifest
+}
+
+func (i *Installer) generateAzureProviderConfig(creds *AzureCredentials) (string, string) {
+	secretManifest := fmt.Sprintf(`apiVersion: v1
+kind: Secret
+metadata:
+  name: azure-credentials
+  namespace: butler-system
+type: Opaque
+stringData:
+  clientID: "%s"
+  clientSecret: "%s"
+  tenantID: "%s"
+  subscriptionID: "%s"
+`, creds.ClientID, creds.ClientSecret, creds.TenantID, creds.SubscriptionID)
+
+	azureConfig := fmt.Sprintf(`    subscriptionID: "%s"
+    resourceGroup: "%s"`, creds.SubscriptionID, creds.ResourceGroup)
+
+	if creds.Location != "" {
+		azureConfig += fmt.Sprintf(`
+    location: "%s"`, creds.Location)
+	}
+	if creds.VNetName != "" {
+		azureConfig += fmt.Sprintf(`
+    vnetName: "%s"`, creds.VNetName)
+	}
+	if creds.SubnetName != "" {
+		azureConfig += fmt.Sprintf(`
+    subnetName: "%s"`, creds.SubnetName)
+	}
+
+	providerConfigManifest := fmt.Sprintf(`apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: azure
+  namespace: butler-system
+spec:
+  provider: azure
+  credentialsRef:
+    name: azure-credentials
+    namespace: butler-system
+  azure:
+%s
+`, azureConfig)
+
+	return secretManifest, providerConfigManifest
+}
+
 // InstallCAPI installs Cluster API with the specified infrastructure providers
 func (i *Installer) InstallCAPI(ctx context.Context, kubeconfig []byte, version string, mgmtProvider string, additionalProviders []butlerv1alpha1.CAPIInfraProviderSpec, creds *ProviderCredentials) error {
 	logger := log.FromContext(ctx)
@@ -1377,6 +1504,12 @@ func (i *Installer) installInfraProvider(ctx context.Context, kubeconfigPath str
 	case "gcp":
 		namespace = "capg-system"
 		providerURL = "https://github.com/kubernetes-sigs/cluster-api-provider-gcp/releases/download/v1.8.0/infrastructure-components.yaml"
+	case "aws":
+		namespace = "capa-system"
+		providerURL = "https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/download/v2.7.0/infrastructure-components.yaml"
+	case "azure":
+		namespace = "capz-system"
+		providerURL = "https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/download/v1.17.0/infrastructure-components.yaml"
 	default:
 		logger.Info("Unknown provider, skipping", "provider", provider)
 		return nil

--- a/internal/addons/installer.go
+++ b/internal/addons/installer.go
@@ -42,6 +42,7 @@ type ProviderCredentials struct {
 	Harvester *HarvesterCredentials
 	VSphere   *VSphereCredentials
 	Proxmox   *ProxmoxCredentials
+	GCP       *GCPCredentials
 }
 
 // NutanixCredentials holds Nutanix Prism Central credentials
@@ -77,6 +78,19 @@ type ProxmoxCredentials struct {
 	Endpoint string
 	Username string
 	Password string
+}
+
+// GCPCredentials holds GCP credentials
+type GCPCredentials struct {
+	ServiceAccountKey string // JSON service account key
+	ProjectID         string
+	Region            string
+	Network           string
+	Subnetwork        string
+	Zone              string
+	MachineType       string
+	ImageProject      string
+	ImageFamily       string
 }
 
 // NewInstaller creates a new addon installer
@@ -968,6 +982,11 @@ func (i *Installer) InstallInitialProviderConfig(ctx context.Context, kubeconfig
 			return fmt.Errorf("harvester credentials required")
 		}
 		secretManifest, providerConfigManifest = i.generateHarvesterProviderConfig(creds.Harvester)
+	case "gcp":
+		if creds == nil || creds.GCP == nil {
+			return fmt.Errorf("gcp credentials required")
+		}
+		secretManifest, providerConfigManifest = i.generateGCPProviderConfig(creds.GCP)
 	default:
 		logger.Info("Provider type not yet supported for ProviderConfig creation, skipping", "provider", providerType)
 		return nil
@@ -1191,6 +1210,63 @@ spec:
 	return secretManifest, providerConfigManifest
 }
 
+func (i *Installer) generateGCPProviderConfig(creds *GCPCredentials) (string, string) {
+	secretManifest := fmt.Sprintf(`apiVersion: v1
+kind: Secret
+metadata:
+  name: gcp-credentials
+  namespace: butler-system
+type: Opaque
+stringData:
+  serviceAccountKey: '%s'
+`, creds.ServiceAccountKey)
+
+	// Build GCP config section
+	gcpConfig := fmt.Sprintf(`    projectID: "%s"
+    region: "%s"`, creds.ProjectID, creds.Region)
+
+	if creds.Network != "" {
+		gcpConfig += fmt.Sprintf(`
+    network: "%s"`, creds.Network)
+	}
+	if creds.Subnetwork != "" {
+		gcpConfig += fmt.Sprintf(`
+    subnetwork: "%s"`, creds.Subnetwork)
+	}
+	if creds.Zone != "" {
+		gcpConfig += fmt.Sprintf(`
+    zone: "%s"`, creds.Zone)
+	}
+	if creds.MachineType != "" {
+		gcpConfig += fmt.Sprintf(`
+    machineType: "%s"`, creds.MachineType)
+	}
+	if creds.ImageProject != "" {
+		gcpConfig += fmt.Sprintf(`
+    imageProject: "%s"`, creds.ImageProject)
+	}
+	if creds.ImageFamily != "" {
+		gcpConfig += fmt.Sprintf(`
+    imageFamily: "%s"`, creds.ImageFamily)
+	}
+
+	providerConfigManifest := fmt.Sprintf(`apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: gcp
+  namespace: butler-system
+spec:
+  provider: gcp
+  credentialsRef:
+    name: gcp-credentials
+    namespace: butler-system
+  gcp:
+%s
+`, gcpConfig)
+
+	return secretManifest, providerConfigManifest
+}
+
 // InstallCAPI installs Cluster API with the specified infrastructure providers
 func (i *Installer) InstallCAPI(ctx context.Context, kubeconfig []byte, version string, mgmtProvider string, additionalProviders []butlerv1alpha1.CAPIInfraProviderSpec, creds *ProviderCredentials) error {
 	logger := log.FromContext(ctx)
@@ -1298,6 +1374,9 @@ func (i *Installer) installInfraProvider(ctx context.Context, kubeconfigPath str
 	case "proxmox":
 		namespace = "capmox-system"
 		providerURL = "https://github.com/ionos-cloud/cluster-api-provider-proxmox/releases/download/v0.6.0/infrastructure-components.yaml"
+	case "gcp":
+		namespace = "capg-system"
+		providerURL = "https://github.com/kubernetes-sigs/cluster-api-provider-gcp/releases/download/v1.8.0/infrastructure-components.yaml"
 	default:
 		logger.Info("Unknown provider, skipping", "provider", provider)
 		return nil

--- a/internal/addons/installer.go
+++ b/internal/addons/installer.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	butlerv1alpha1 "github.com/butlerdotdev/butler-api/api/v1alpha1"
+	"github.com/butlerdotdev/butler-bootstrap/internal/crds"
 
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -907,7 +908,8 @@ func (i *Installer) InstallButler(ctx context.Context, kubeconfig []byte) error 
 	return nil
 }
 
-// InstallButlerCRDs installs Butler platform CRDs via Helm chart
+// InstallButlerCRDs installs Butler platform CRDs via Helm chart and overlays
+// embedded CRDs to ensure cloud provider fields are present.
 func (i *Installer) InstallButlerCRDs(ctx context.Context, kubeconfig []byte, version string) error {
 	logger := log.FromContext(ctx)
 	logger.Info("Installing Butler platform CRDs", "version", version)
@@ -923,7 +925,7 @@ func (i *Installer) InstallButlerCRDs(ctx context.Context, kubeconfig []byte, ve
 	}
 
 	if version == "" {
-		version = "0.1.0"
+		version = "0.6.0"
 	}
 
 	args := []string{
@@ -938,6 +940,12 @@ func (i *Installer) InstallButlerCRDs(ctx context.Context, kubeconfig []byte, ve
 
 	if err := i.runHelm(ctx, kubeconfigPath, args...); err != nil {
 		return fmt.Errorf("failed to install butler-crds: %w", err)
+	}
+
+	// Overlay embedded CRDs to ensure cloud provider fields and any
+	// dev-branch CRD changes are present on the target cluster.
+	if err := i.applyEmbeddedCRDs(ctx, kubeconfigPath); err != nil {
+		logger.Info("Failed to overlay embedded CRDs (non-fatal)", "error", err)
 	}
 
 	// Wait for all Butler CRDs to be established (discover dynamically)
@@ -1018,6 +1026,51 @@ func (i *Installer) waitForButlerCRDs(ctx context.Context, kubeconfigPath string
 		if err := i.runKubectl(ctx, kubeconfigPath, args...); err != nil {
 			logger.Info("CRD wait timeout (may already be ready)", "crd", crd)
 		}
+	}
+
+	return nil
+}
+
+// applyEmbeddedCRDs applies the embedded CRD YAML files to the target cluster.
+// This overlays any fields that are present in the build but not yet released
+// in the butler-crds Helm chart (e.g., cloud provider fields on ProviderConfig).
+func (i *Installer) applyEmbeddedCRDs(ctx context.Context, kubeconfigPath string) error {
+	logger := log.FromContext(ctx)
+
+	entries, err := crds.PlatformCRDs.ReadDir(".")
+	if err != nil {
+		return fmt.Errorf("failed to read embedded CRDs: %w", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yaml") {
+			continue
+		}
+
+		data, err := crds.PlatformCRDs.ReadFile(entry.Name())
+		if err != nil {
+			logger.Info("Failed to read embedded CRD", "file", entry.Name(), "error", err)
+			continue
+		}
+
+		tmpFile, err := os.CreateTemp("", "crd-*.yaml")
+		if err != nil {
+			return fmt.Errorf("failed to create temp file: %w", err)
+		}
+		tmpPath := tmpFile.Name()
+
+		if _, err := tmpFile.Write(data); err != nil {
+			tmpFile.Close()
+			os.Remove(tmpPath)
+			return fmt.Errorf("failed to write CRD temp file: %w", err)
+		}
+		tmpFile.Close()
+
+		logger.Info("Applying embedded CRD", "file", entry.Name())
+		if err := i.runKubectl(ctx, kubeconfigPath, "apply", "--server-side", "--force-conflicts", "-f", tmpPath); err != nil {
+			logger.Info("Failed to apply embedded CRD (non-fatal)", "file", entry.Name(), "error", err)
+		}
+		os.Remove(tmpPath)
 	}
 
 	return nil
@@ -1494,9 +1547,13 @@ func (i *Installer) InstallCAPI(ctx context.Context, kubeconfig []byte, version 
 	if err := i.runKubectl(ctx, kubeconfigPath, "apply", "--server-side", "--force-conflicts", "-f", stewardURL); err != nil {
 		return fmt.Errorf("failed to install Steward CAPI provider: %w", err)
 	}
-	// Install infrastructure provider manually with credentials
+	// Install infrastructure provider manually with credentials.
+	// Non-fatal: CAPI infra providers (CAPG, CAPA, CAPZ) have webhook CRDs with
+	// placeholder caBundle that cert-manager's ca-injector must populate. If the
+	// CA hasn't propagated yet, kubectl apply rejects the invalid PEM. The
+	// provider can be installed post-bootstrap; core + capi-steward are sufficient.
 	if err := i.installInfraProvider(ctx, kubeconfigPath, mgmtProvider, creds); err != nil {
-		return fmt.Errorf("failed to install %s provider: %w", mgmtProvider, err)
+		logger.Info("Infrastructure provider install failed (non-fatal, can be installed post-bootstrap)", "provider", mgmtProvider, "error", err)
 	}
 
 	// Install any additional providers
@@ -1590,6 +1647,11 @@ func (i *Installer) installInfraProvider(ctx context.Context, kubeconfigPath str
 	if provider == "nutanix" && creds != nil && creds.Nutanix != nil {
 		manifest = i.substituteNutanixCredentials(manifest, creds.Nutanix)
 	}
+	if provider == "gcp" && creds != nil && creds.GCP != nil {
+		manifest = i.substituteGCPVariables(manifest, creds.GCP)
+	}
+	// For any remaining ${VAR:=default} patterns, substitute the default value
+	manifest = substituteDefaults(manifest)
 
 	// Write processed manifest to temp file
 	tmpFile, err := os.CreateTemp("", "provider-*.yaml")
@@ -1651,6 +1713,41 @@ func (i *Installer) substituteNutanixCredentials(manifest string, creds *Nutanix
 		manifest = strings.ReplaceAll(manifest, placeholder, value)
 	}
 
+	return manifest
+}
+
+// substituteGCPVariables replaces CAPG template variables with actual values.
+// The CAPG infrastructure-components.yaml uses ${GCP_B64ENCODED_CREDENTIALS}
+// for the credentials secret and ${VAR:=default} patterns for feature gates.
+func (i *Installer) substituteGCPVariables(manifest string, creds *GCPCredentials) string {
+	b64Creds := base64.StdEncoding.EncodeToString([]byte(creds.ServiceAccountKey))
+	manifest = strings.ReplaceAll(manifest, "${GCP_B64ENCODED_CREDENTIALS}", b64Creds)
+	return manifest
+}
+
+// substituteDefaults replaces remaining ${VAR:=default} patterns with their default values.
+// This handles shell-style variable substitution patterns commonly found in CAPI manifests.
+func substituteDefaults(manifest string) string {
+	for {
+		idx := strings.Index(manifest, "${")
+		if idx == -1 {
+			break
+		}
+		end := strings.Index(manifest[idx:], "}")
+		if end == -1 {
+			break
+		}
+		end += idx
+		expr := manifest[idx+2 : end] // contents between ${ and }
+		// Handle ${VAR:=default} pattern
+		if colonIdx := strings.Index(expr, ":="); colonIdx != -1 {
+			defaultVal := expr[colonIdx+2:]
+			manifest = manifest[:idx] + defaultVal + manifest[end+1:]
+			continue
+		}
+		// Skip patterns we don't understand (move past to avoid infinite loop)
+		break
+	}
 	return manifest
 }
 
@@ -1900,7 +1997,7 @@ spec:
 func (i *Installer) InstallConsole(ctx context.Context, kubeconfig []byte, spec *butlerv1alpha1.ConsoleAddonSpec, clusterName string) (string, error) {
 	logger := log.FromContext(ctx)
 
-	version := "0.1.0"
+	version := "0.4.1"
 	if spec != nil && spec.Version != "" {
 		version = spec.Version
 	}
@@ -1915,6 +2012,13 @@ func (i *Installer) InstallConsole(ctx context.Context, kubeconfig []byte, spec 
 
 	if err := i.ensurePrivilegedNamespace(ctx, kubeconfigPath, "butler-system"); err != nil {
 		return "", fmt.Errorf("failed to prepare butler-system namespace: %w", err)
+	}
+
+	// The butler-console chart has RBAC resources in steward-system namespace
+	// (for Steward deployment restart during cert rotation). Ensure the
+	// namespace exists so Helm doesn't fail creating the Role/RoleBinding.
+	if err := i.ensurePrivilegedNamespace(ctx, kubeconfigPath, "steward-system"); err != nil {
+		return "", fmt.Errorf("failed to prepare steward-system namespace: %w", err)
 	}
 
 	// Build helm values

--- a/internal/controller/clusterbootstrap_controller.go
+++ b/internal/controller/clusterbootstrap_controller.go
@@ -1196,6 +1196,8 @@ func (r *ClusterBootstrapReconciler) getDefaultVIPInterface(provider string) str
 		return "enp1s0"
 	case "proxmox":
 		return "eth0"
+	case "gcp":
+		return "ens4"
 	default:
 		return "eth0"
 	}
@@ -1267,6 +1269,16 @@ func (r *ClusterBootstrapReconciler) getProviderCredentials(ctx context.Context,
 			Username: string(secret.Data["username"]),
 			Password: string(secret.Data["password"]),
 		}
+	case "gcp":
+		creds.GCP = &addons.GCPCredentials{
+			ServiceAccountKey: string(secret.Data["serviceAccountKey"]),
+			ProjectID:         providerConfig.Spec.GCP.ProjectID,
+			Region:            providerConfig.Spec.GCP.Region,
+		}
+		if providerConfig.Spec.GCP.Network != "" {
+			creds.GCP.Network = providerConfig.Spec.GCP.Network
+		}
+		logger.Info("Retrieved GCP credentials", "projectID", creds.GCP.ProjectID, "region", creds.GCP.Region)
 	}
 
 	return creds, nil
@@ -1343,6 +1355,21 @@ func (r *ClusterBootstrapReconciler) extractProviderCredentials(ctx context.Cont
 		logger.Info("Extracted Harvester credentials",
 			"namespace", creds.Harvester.Namespace,
 			"networkName", creds.Harvester.NetworkName)
+
+	case "gcp":
+		if providerConfig.Spec.GCP == nil {
+			return nil, fmt.Errorf("ProviderConfig %s has no gcp configuration", providerConfigKey)
+		}
+		creds.GCP = &addons.GCPCredentials{
+			ServiceAccountKey: string(secret.Data["serviceAccountKey"]),
+			ProjectID:         providerConfig.Spec.GCP.ProjectID,
+			Region:            providerConfig.Spec.GCP.Region,
+			Network:           providerConfig.Spec.GCP.Network,
+			Subnetwork:        providerConfig.Spec.GCP.Subnetwork,
+		}
+		logger.Info("Extracted GCP credentials",
+			"projectID", creds.GCP.ProjectID,
+			"region", creds.GCP.Region)
 
 	default:
 		logger.Info("Unknown or unsupported provider type", "provider", cb.Spec.Provider)

--- a/internal/controller/clusterbootstrap_controller.go
+++ b/internal/controller/clusterbootstrap_controller.go
@@ -756,20 +756,14 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 		}
 	}
 
-	// 2.5 Cloud Controller Manager - cloud providers only.
-	// Replaces MetalLB for LoadBalancer service provisioning on cloud.
+	// 2.5 Cloud Controller Manager - skipped for management cluster bootstrap.
+	// Management clusters don't need CCM. Setting --cloud-provider=external
+	// on kubelet adds an "uninitialized" taint that blocks all pod scheduling
+	// until CCM runs, creating a deadlock. Tenant clusters on cloud providers
+	// get CCM installed by butler-controller via CAPI machine templates.
 	if cb.IsCloudProvider() {
-		if !r.isAddonInstalled(cb, "cloud-controller-manager") {
-			logger.Info("Installing Cloud Controller Manager", "provider", cb.Spec.Provider)
-			if err := r.AddonInstaller.InstallCloudControllerManager(ctx, kubeconfig, cb.Spec.Provider); err != nil {
-				logger.Error(err, "Failed to install Cloud Controller Manager — LoadBalancer services will remain Pending until CCM is installed. NodePort and port-forward still work.")
-			}
-
-			r.setAddonInstalled(cb, "cloud-controller-manager")
-			if err := r.Status().Update(ctx, cb); err != nil {
-				logger.Info("Failed to update status after CCM install", "error", err)
-			}
-		}
+		r.ensureAddonsMap(cb)
+		cb.Status.AddonsInstalled["cloud-controller-manager"] = true
 	}
 
 	// 3. cert-manager - needed by Traefik and Steward webhooks

--- a/internal/controller/clusterbootstrap_controller.go
+++ b/internal/controller/clusterbootstrap_controller.go
@@ -611,7 +611,8 @@ func (r *ClusterBootstrapReconciler) reconcileBootstrappingCluster(ctx context.C
 			// Retry on transient errors (node still booting)
 			if strings.Contains(err.Error(), "connection refused") ||
 				strings.Contains(err.Error(), "connection reset") ||
-				strings.Contains(err.Error(), "i/o timeout") {
+				strings.Contains(err.Error(), "i/o timeout") ||
+				strings.Contains(err.Error(), "bootstrap is not available yet") {
 				logger.Info("Bootstrap failed, node may still be starting, retrying", "error", err)
 				return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 			}
@@ -833,9 +834,14 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 		}
 	}
 
-	// 6. Traefik ingress - after MetalLB so it can get LoadBalancer IP
-	if addons.Ingress == nil || isAddonEnabled(addons.Ingress.Enabled) {
-		if !r.isAddonInstalled(cb, "traefik") {
+	// 6. Traefik ingress - after MetalLB so it can get LoadBalancer IP.
+	// Cloud providers skip Traefik because there is no MetalLB or CCM to
+	// allocate LoadBalancer IPs on the management cluster. Traefik's LB
+	// Service stays <pending> and Helm --wait times out.
+	if !r.isAddonInstalled(cb, "traefik") {
+		if cb.IsCloudProvider() {
+			logger.Info("Skipping Traefik (cloud provider has no MetalLB/CCM for LoadBalancer)")
+		} else if addons.Ingress == nil || isAddonEnabled(addons.Ingress.Enabled) {
 			logger.Info("Installing Traefik")
 			version := ""
 			if addons.Ingress != nil && addons.Ingress.Version != "" {
@@ -847,11 +853,12 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 				return ctrl.Result{RequeueAfter: requeueShort}, nil
 			}
 
-			r.setAddonInstalled(cb, "traefik")
 			logger.Info("Traefik installed successfully")
-			if err := r.Status().Update(ctx, cb); err != nil {
-				logger.Info("Failed to update status after Traefik install", "error", err)
-			}
+		}
+
+		r.setAddonInstalled(cb, "traefik")
+		if err := r.Status().Update(ctx, cb); err != nil {
+			logger.Info("Failed to update status after Traefik step", "error", err)
 		}
 	}
 
@@ -972,7 +979,7 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 		if !r.isAddonInstalled(cb, "butler-crds") {
 			logger.Info("Installing Butler CRDs")
 
-			if err := r.AddonInstaller.InstallButlerCRDs(ctx, kubeconfig, "0.1.0"); err != nil {
+			if err := r.AddonInstaller.InstallButlerCRDs(ctx, kubeconfig, ""); err != nil {
 				logger.Error(err, "Failed to install Butler CRDs")
 				return ctrl.Result{RequeueAfter: requeueShort}, nil
 			}

--- a/internal/controller/clusterbootstrap_controller.go
+++ b/internal/controller/clusterbootstrap_controller.go
@@ -100,6 +100,7 @@ type AddonInstallerInterface interface {
 	InstallCertManager(ctx context.Context, kubeconfig []byte, version string) error
 	InstallLonghorn(ctx context.Context, kubeconfig []byte, version string, replicaCount int32) error
 	InstallMetalLB(ctx context.Context, kubeconfig []byte, addressPool string, topology string) error
+	InstallCloudControllerManager(ctx context.Context, kubeconfig []byte, provider string) error
 	InstallTraefik(ctx context.Context, kubeconfig []byte, version string) error
 	InstallGatewayAPI(ctx context.Context, kubeconfig []byte, version string) error // NEW: Gateway API CRDs
 	// InstallStewardCRDs(ctx context.Context, kubeconfig []byte, version string) error // NEW: Steward CRDs (optional)
@@ -702,9 +703,9 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 
 	// 1. kube-vip - required for VIP to work on on-prem providers.
 	// Cloud providers (gcp, aws, azure) skip kube-vip because cloud networks
-	// do not support gratuitous ARP. The first CP node IP is used instead.
+	// do not support gratuitous ARP. Cloud HA uses a cloud load balancer instead.
 	if !r.isAddonInstalled(cb, "kube-vip") {
-		if cb.Spec.Network.VIP != "" {
+		if cb.Spec.Network.VIP != "" && !cb.IsCloudProvider() {
 			logger.Info("Installing kube-vip")
 			version := "v0.8.7"
 			if addons.ControlPlaneHA != nil && addons.ControlPlaneHA.Version != "" {
@@ -721,8 +722,10 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 				return ctrl.Result{RequeueAfter: requeueShort}, nil
 			}
 			logger.Info("kube-vip installed successfully")
+		} else if cb.IsCloudProvider() {
+			logger.Info("Skipping kube-vip (cloud provider uses cloud load balancer)")
 		} else {
-			logger.Info("Skipping kube-vip, no VIP configured (cloud provider)")
+			logger.Info("Skipping kube-vip (no VIP configured)")
 		}
 
 		r.setAddonInstalled(cb, "kube-vip")
@@ -749,6 +752,22 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 			logger.Info("Cilium installed successfully")
 			if err := r.Status().Update(ctx, cb); err != nil {
 				logger.Info("Failed to update status after Cilium install", "error", err)
+			}
+		}
+	}
+
+	// 2.5 Cloud Controller Manager - cloud providers only.
+	// Replaces MetalLB for LoadBalancer service provisioning on cloud.
+	if cb.IsCloudProvider() {
+		if !r.isAddonInstalled(cb, "cloud-controller-manager") {
+			logger.Info("Installing Cloud Controller Manager", "provider", cb.Spec.Provider)
+			if err := r.AddonInstaller.InstallCloudControllerManager(ctx, kubeconfig, cb.Spec.Provider); err != nil {
+				logger.Error(err, "Failed to install Cloud Controller Manager — LoadBalancer services will remain Pending until CCM is installed. NodePort and port-forward still work.")
+			}
+
+			r.setAddonInstalled(cb, "cloud-controller-manager")
+			if err := r.Status().Update(ctx, cb); err != nil {
+				logger.Info("Failed to update status after CCM install", "error", err)
 			}
 		}
 	}

--- a/internal/controller/clusterbootstrap_controller.go
+++ b/internal/controller/clusterbootstrap_controller.go
@@ -463,9 +463,15 @@ func (r *ClusterBootstrapReconciler) reconcileConfiguringTalos(ctx context.Conte
 		cpIPs := r.getControlPlaneIPs(cb)
 		workerIPs := r.getWorkerIPs(cb)
 
+		endpoint := r.resolveControlPlaneEndpoint(cb)
+		if endpoint == "" {
+			logger.Info("Control plane endpoint not yet available (no VIP and no CP IPs discovered), requeueing")
+			return ctrl.Result{RequeueAfter: requeueShort}, nil
+		}
+
 		opts := TalosConfigOptions{
 			ClusterName:                    cb.Spec.Cluster.Name,
-			ControlPlaneVIP:                r.resolveControlPlaneEndpoint(cb),
+			ControlPlaneVIP:                endpoint,
 			ControlPlaneIPs:                cpIPs,
 			WorkerIPs:                      workerIPs,
 			PodCIDR:                        cb.Spec.Network.PodCIDR,

--- a/internal/controller/clusterbootstrap_controller.go
+++ b/internal/controller/clusterbootstrap_controller.go
@@ -72,6 +72,7 @@ type TalosConfigOptions struct {
 	ServiceCIDR                    string
 	TalosVersion                   string
 	InstallDisk                    string
+	Platform                       string // Cloud platform for Talos metadata discovery (gcp, aws, azure). Empty for on-prem.
 	ConfigPatches                  []ConfigPatch
 	AllowSchedulingOnControlPlanes bool // For single-node topology
 }
@@ -463,13 +464,14 @@ func (r *ClusterBootstrapReconciler) reconcileConfiguringTalos(ctx context.Conte
 
 		opts := TalosConfigOptions{
 			ClusterName:                    cb.Spec.Cluster.Name,
-			ControlPlaneVIP:                cb.Spec.Network.VIP,
+			ControlPlaneVIP:                r.resolveControlPlaneEndpoint(cb),
 			ControlPlaneIPs:                cpIPs,
 			WorkerIPs:                      workerIPs,
 			PodCIDR:                        cb.Spec.Network.PodCIDR,
 			ServiceCIDR:                    cb.Spec.Network.ServiceCIDR,
 			TalosVersion:                   cb.Spec.Talos.Version,
 			InstallDisk:                    cb.Spec.Talos.InstallDisk,
+			Platform:                       r.getTalosPlatform(cb.Spec.Provider),
 			AllowSchedulingOnControlPlanes: cb.IsSingleNode(), // Enable for single-node
 		}
 
@@ -634,7 +636,7 @@ func (r *ClusterBootstrapReconciler) reconcileBootstrappingCluster(ctx context.C
 		}
 
 		cb.Status.Kubeconfig = base64.StdEncoding.EncodeToString(kubeconfig)
-		cb.Status.ControlPlaneEndpoint = fmt.Sprintf("https://%s:6443", cb.Spec.Network.VIP)
+		cb.Status.ControlPlaneEndpoint = fmt.Sprintf("https://%s:6443", r.resolveControlPlaneEndpoint(cb))
 		if err := r.Status().Update(ctx, cb); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -698,28 +700,34 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 
 	addons := cb.Spec.Addons
 
-	// 1. kube-vip - required for VIP to work
+	// 1. kube-vip - required for VIP to work on on-prem providers.
+	// Cloud providers (gcp, aws, azure) skip kube-vip because cloud networks
+	// do not support gratuitous ARP. The first CP node IP is used instead.
 	if !r.isAddonInstalled(cb, "kube-vip") {
-		logger.Info("Installing kube-vip")
-		version := "v0.8.7"
-		if addons.ControlPlaneHA != nil && addons.ControlPlaneHA.Version != "" {
-			version = addons.ControlPlaneHA.Version
-		}
+		if cb.Spec.Network.VIP != "" {
+			logger.Info("Installing kube-vip")
+			version := "v0.8.7"
+			if addons.ControlPlaneHA != nil && addons.ControlPlaneHA.Version != "" {
+				version = addons.ControlPlaneHA.Version
+			}
 
-		iface := cb.Spec.Network.VIPInterface
-		if iface == "" {
-			iface = r.getDefaultVIPInterface(cb.Spec.Provider)
-		}
+			iface := cb.Spec.Network.VIPInterface
+			if iface == "" {
+				iface = r.getDefaultVIPInterface(cb.Spec.Provider)
+			}
 
-		if err := r.AddonInstaller.InstallKubeVip(ctx, kubeconfig, cb.Spec.Network.VIP, iface, version); err != nil {
-			logger.Error(err, "Failed to install kube-vip")
-			return ctrl.Result{RequeueAfter: requeueShort}, nil
+			if err := r.AddonInstaller.InstallKubeVip(ctx, kubeconfig, cb.Spec.Network.VIP, iface, version); err != nil {
+				logger.Error(err, "Failed to install kube-vip")
+				return ctrl.Result{RequeueAfter: requeueShort}, nil
+			}
+			logger.Info("kube-vip installed successfully")
+		} else {
+			logger.Info("Skipping kube-vip, no VIP configured (cloud provider)")
 		}
 
 		r.setAddonInstalled(cb, "kube-vip")
-		logger.Info("kube-vip installed successfully")
 		if err := r.Status().Update(ctx, cb); err != nil {
-			logger.Info("Failed to update status after kube-vip install", "error", err)
+			logger.Info("Failed to update status after kube-vip step", "error", err)
 		}
 	}
 
@@ -1187,6 +1195,36 @@ func (r *ClusterBootstrapReconciler) getWorkerIPs(cb *butlerv1alpha1.ClusterBoot
 	return ips
 }
 
+// resolveControlPlaneEndpoint returns the control plane API server endpoint.
+// For on-prem providers with kube-vip, this is the VIP. For cloud providers
+// without VIP, this is the first control plane node's IP.
+func (r *ClusterBootstrapReconciler) resolveControlPlaneEndpoint(cb *butlerv1alpha1.ClusterBootstrap) string {
+	if cb.Spec.Network.VIP != "" {
+		return cb.Spec.Network.VIP
+	}
+	cpIPs := r.getControlPlaneIPs(cb)
+	if len(cpIPs) > 0 {
+		return cpIPs[0]
+	}
+	return ""
+}
+
+// getTalosPlatform maps the bootstrap provider to a Talos platform identifier.
+// Cloud platforms need this so Talos can query instance metadata services for
+// networking configuration and cloud-init data.
+func (r *ClusterBootstrapReconciler) getTalosPlatform(provider string) string {
+	switch provider {
+	case "gcp":
+		return "gcp"
+	case "aws":
+		return "aws"
+	case "azure":
+		return "azure"
+	default:
+		return "" // on-prem providers use the default metal platform
+	}
+}
+
 // getDefaultVIPInterface returns the default network interface name for kube-vip based on provider
 func (r *ClusterBootstrapReconciler) getDefaultVIPInterface(provider string) string {
 	switch provider {
@@ -1279,6 +1317,34 @@ func (r *ClusterBootstrapReconciler) getProviderCredentials(ctx context.Context,
 			creds.GCP.Network = providerConfig.Spec.GCP.Network
 		}
 		logger.Info("Retrieved GCP credentials", "projectID", creds.GCP.ProjectID, "region", creds.GCP.Region)
+	case "aws":
+		creds.AWS = &addons.AWSCredentials{
+			AccessKeyID:    string(secret.Data["accessKeyID"]),
+			SecretAccessKey: string(secret.Data["secretAccessKey"]),
+			Region:          providerConfig.Spec.AWS.Region,
+		}
+		if providerConfig.Spec.AWS.VPCID != "" {
+			creds.AWS.VPCID = providerConfig.Spec.AWS.VPCID
+		}
+		if len(providerConfig.Spec.AWS.SubnetIDs) > 0 {
+			creds.AWS.SubnetID = providerConfig.Spec.AWS.SubnetIDs[0]
+		}
+		if len(providerConfig.Spec.AWS.SecurityGroupIDs) > 0 {
+			creds.AWS.SecurityGroupID = providerConfig.Spec.AWS.SecurityGroupIDs[0]
+		}
+		logger.Info("Retrieved AWS credentials", "region", creds.AWS.Region)
+	case "azure":
+		creds.Azure = &addons.AzureCredentials{
+			ClientID:       string(secret.Data["clientID"]),
+			ClientSecret:   string(secret.Data["clientSecret"]),
+			TenantID:       string(secret.Data["tenantID"]),
+			SubscriptionID: string(secret.Data["subscriptionID"]),
+			ResourceGroup:  providerConfig.Spec.Azure.ResourceGroup,
+			Location:       providerConfig.Spec.Azure.Location,
+			VNetName:       providerConfig.Spec.Azure.VNetName,
+			SubnetName:     providerConfig.Spec.Azure.SubnetName,
+		}
+		logger.Info("Retrieved Azure credentials", "subscriptionID", creds.Azure.SubscriptionID, "resourceGroup", creds.Azure.ResourceGroup)
 	}
 
 	return creds, nil
@@ -1370,6 +1436,44 @@ func (r *ClusterBootstrapReconciler) extractProviderCredentials(ctx context.Cont
 		logger.Info("Extracted GCP credentials",
 			"projectID", creds.GCP.ProjectID,
 			"region", creds.GCP.Region)
+
+	case "aws":
+		if providerConfig.Spec.AWS == nil {
+			return nil, fmt.Errorf("ProviderConfig %s has no aws configuration", providerConfigKey)
+		}
+		creds.AWS = &addons.AWSCredentials{
+			AccessKeyID:    string(secret.Data["accessKeyID"]),
+			SecretAccessKey: string(secret.Data["secretAccessKey"]),
+			Region:          providerConfig.Spec.AWS.Region,
+			VPCID:           providerConfig.Spec.AWS.VPCID,
+		}
+		if len(providerConfig.Spec.AWS.SubnetIDs) > 0 {
+			creds.AWS.SubnetID = providerConfig.Spec.AWS.SubnetIDs[0]
+		}
+		if len(providerConfig.Spec.AWS.SecurityGroupIDs) > 0 {
+			creds.AWS.SecurityGroupID = providerConfig.Spec.AWS.SecurityGroupIDs[0]
+		}
+		logger.Info("Extracted AWS credentials",
+			"region", creds.AWS.Region,
+			"vpcID", creds.AWS.VPCID)
+
+	case "azure":
+		if providerConfig.Spec.Azure == nil {
+			return nil, fmt.Errorf("ProviderConfig %s has no azure configuration", providerConfigKey)
+		}
+		creds.Azure = &addons.AzureCredentials{
+			ClientID:       string(secret.Data["clientID"]),
+			ClientSecret:   string(secret.Data["clientSecret"]),
+			TenantID:       string(secret.Data["tenantID"]),
+			SubscriptionID: string(secret.Data["subscriptionID"]),
+			ResourceGroup:  providerConfig.Spec.Azure.ResourceGroup,
+			Location:       providerConfig.Spec.Azure.Location,
+			VNetName:       providerConfig.Spec.Azure.VNetName,
+			SubnetName:     providerConfig.Spec.Azure.SubnetName,
+		}
+		logger.Info("Extracted Azure credentials",
+			"subscriptionID", creds.Azure.SubscriptionID,
+			"resourceGroup", creds.Azure.ResourceGroup)
 
 	default:
 		logger.Info("Unknown or unsupported provider type", "provider", cb.Spec.Provider)
@@ -1524,10 +1628,12 @@ func (r *ClusterBootstrapReconciler) reconcileImageSync(ctx context.Context, cb 
 	// When multi-arch support is added, this should read from the ClusterBootstrap spec.
 	arch := "amd64"
 	// Platform is the artifact name prefix in the factory URL.
-	// For Butler Image Factory: use "talos" (bootstrap always uses Talos).
-	// For Siderolabs factory (factory.talos.dev): use "nocloud" (or metal, vmware, etc.).
-	// Bootstrap always uses Talos for management clusters.
+	// Platform for ImageSync. On-prem uses "talos" (Butler Image Factory naming).
+	// Cloud providers use the cloud platform name for cloud-specific image variants.
 	platform := "talos"
+	if cb.IsCloudProvider() {
+		platform = cb.Spec.Provider
+	}
 
 	// Truncate schematicID to 63 chars for label value (Kubernetes label limit)
 	labelSchematicID := schematicID

--- a/internal/crds/butler.butlerlabs.dev_butlerconfigs.yaml
+++ b/internal/crds/butler.butlerlabs.dev_butlerconfigs.yaml
@@ -21,6 +21,10 @@ spec:
       jsonPath: .spec.multiTenancy.mode
       name: Mode
       type: string
+    - description: Git provider
+      jsonPath: .spec.gitProvider.type
+      name: Git
+      type: string
     - description: Number of teams
       jsonPath: .status.teamCount
       name: Teams
@@ -60,6 +64,55 @@ spec:
           spec:
             description: ButlerConfigSpec defines the desired state of ButlerConfig.
             properties:
+              controlPlaneExposure:
+                description: |-
+                  ControlPlaneExposure configures how tenant control planes are exposed.
+                  This is a platform-level setting populated from ClusterBootstrap during
+                  initial setup and inherited by all TenantClusters.
+                properties:
+                  controllerType:
+                    description: |-
+                      ControllerType specifies the ingress controller type for automatic TLS passthrough.
+                      Used when Mode is Ingress. Supported values:
+                      - "haproxy": Uses haproxy.org/ssl-passthrough annotation
+                      - "nginx": Uses nginx.ingress.kubernetes.io/ssl-passthrough annotation
+                      - "traefik": Creates IngressRouteTCP instead of standard Ingress
+                      - "generic": No automatic annotations, use custom annotations in Steward config
+                    enum:
+                    - haproxy
+                    - nginx
+                    - traefik
+                    - generic
+                    type: string
+                  gatewayRef:
+                    description: |-
+                      GatewayRef references the Gateway resource when Mode is Gateway.
+                      Format: "namespace/name"
+                    type: string
+                  hostname:
+                    description: |-
+                      Hostname is the wildcard domain for tenant API servers.
+                      Required when Mode is Ingress or Gateway.
+                      Example: "*.k8s.platform.example.com"
+                      Tenant clusters get: "{cluster}.{namespace}.k8s.platform.example.com"
+                    type: string
+                  ingressClassName:
+                    description: IngressClassName specifies the Ingress class when
+                      Mode is Ingress.
+                    type: string
+                  mode:
+                    default: LoadBalancer
+                    description: |-
+                      Mode determines how tenant API servers are exposed.
+                      LoadBalancer: 1 IP per tenant, direct access (default)
+                      Ingress: L7 proxy via Ingress controller with TLS passthrough, shared IP
+                      Gateway: L4/L7 via Gateway API TLSRoute, shared IP
+                    enum:
+                    - LoadBalancer
+                    - Ingress
+                    - Gateway
+                    type: string
+                type: object
               defaultAddonVersions:
                 description: |-
                   DefaultAddonVersions specifies the default versions for addons.
@@ -83,6 +136,134 @@ spec:
                   traefik:
                     description: Traefik version.
                     type: string
+                type: object
+              defaultControlPlaneResources:
+                description: |-
+                  DefaultControlPlaneResources configures default resource allocations for
+                  tenant control plane components (apiserver, controller-manager, scheduler).
+                  Applied to new TenantClusters when they don't specify per-cluster overrides.
+                  If not set, pods run with no resource requests (BestEffort QoS).
+                properties:
+                  apiServer:
+                    description: APIServer resource requirements.
+                    properties:
+                      limits:
+                        description: Limits describes the maximum resources allowed.
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: CPU resource (e.g., "100m", "1", "2").
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Memory resource (e.g., "128Mi", "1Gi").
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        description: Requests describes the minimum resources required.
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: CPU resource (e.g., "100m", "1", "2").
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Memory resource (e.g., "128Mi", "1Gi").
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                  controllerManager:
+                    description: ControllerManager resource requirements.
+                    properties:
+                      limits:
+                        description: Limits describes the maximum resources allowed.
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: CPU resource (e.g., "100m", "1", "2").
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Memory resource (e.g., "128Mi", "1Gi").
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        description: Requests describes the minimum resources required.
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: CPU resource (e.g., "100m", "1", "2").
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Memory resource (e.g., "128Mi", "1Gi").
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                  scheduler:
+                    description: Scheduler resource requirements.
+                    properties:
+                      limits:
+                        description: Limits describes the maximum resources allowed.
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: CPU resource (e.g., "100m", "1", "2").
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Memory resource (e.g., "128Mi", "1Gi").
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        description: Requests describes the minimum resources required.
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: CPU resource (e.g., "100m", "1", "2").
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Memory resource (e.g., "128Mi", "1Gi").
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
                 type: object
               defaultNamespace:
                 default: butler-tenants
@@ -143,6 +324,95 @@ spec:
                     minimum: 1
                     type: integer
                 type: object
+              gitProvider:
+                description: |-
+                  GitProvider configures the default Git provider for GitOps operations.
+                  This enables features like exporting clusters to GitOps, enabling Flux
+                  on clusters, and managing addons via Git repositories.
+                properties:
+                  organization:
+                    description: |-
+                      Organization is the default organization/group for repositories.
+                      When set, repository listings will be scoped to this org.
+                    type: string
+                  secretRef:
+                    description: |-
+                      SecretRef references the Secret containing credentials.
+                      Required keys depend on provider type:
+                      - GitHub: "token" (Personal Access Token with repo scope)
+                      - GitLab: "token" (Personal Access Token with api scope)
+                      - Bitbucket: "username" and "app-password"
+                    properties:
+                      name:
+                        description: Name is the name of the resource.
+                        minLength: 1
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type:
+                    description: Type is the Git provider type.
+                    enum:
+                    - github
+                    - gitlab
+                    - bitbucket
+                    type: string
+                  url:
+                    default: https://api.github.com
+                    description: |-
+                      URL is the Git provider API URL.
+                      For GitHub: https://api.github.com (or https://github.example.com/api/v3 for enterprise)
+                      For GitLab: https://gitlab.com (or self-hosted URL)
+                    type: string
+                required:
+                - secretRef
+                - type
+                type: object
+              imageFactory:
+                description: |-
+                  ImageFactory configures the Butler Image Factory connection.
+                  Required for automatic image syncing to infrastructure providers.
+                properties:
+                  autoSync:
+                    default: true
+                    description: |-
+                      AutoSync enables automatic image syncing when a TenantCluster references
+                      an image not yet available on the target provider.
+                    type: boolean
+                  credentialsRef:
+                    description: |-
+                      CredentialsRef references the Secret containing the factory API key.
+                      The Secret must contain a key named "apiKey".
+                    properties:
+                      key:
+                        description: |-
+                          Key is the key within the Secret to reference.
+                          If not specified, the entire Secret data is used.
+                        type: string
+                      name:
+                        description: Name is the name of the Secret.
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace is the namespace of the Secret.
+                          If not specified, the namespace of the referencing resource is used.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  defaultSchematicID:
+                    description: |-
+                      DefaultSchematicID is the default schematic used when TenantClusters
+                      don't specify one. Content-addressable SHA-256 hex string.
+                    type: string
+                  url:
+                    description: URL is the base URL of the Image Factory API.
+                    pattern: ^https?://
+                    type: string
+                required:
+                - url
+                type: object
               multiTenancy:
                 description: MultiTenancy configures how multi-tenancy is handled.
                 properties:
@@ -155,6 +425,107 @@ spec:
                     - Disabled
                     type: string
                 type: object
+              observability:
+                description: Observability configures platform-level observability
+                  (pipeline, collection defaults).
+                properties:
+                  collection:
+                    description: Collection configures default collection settings
+                      for tenant clusters.
+                    properties:
+                      autoEnroll:
+                        description: |-
+                          AutoEnroll controls which observability agents are automatically installed
+                          on new tenant clusters when they reach Ready phase.
+                        properties:
+                          otelCollector:
+                            description: |-
+                              OtelCollector enables automatic installation of the OpenTelemetry Collector.
+                              Requires pipeline.traceEndpoint to be configured.
+                            type: boolean
+                          prometheus:
+                            description: |-
+                              Prometheus enables automatic installation of the Prometheus monitoring stack.
+                              Requires pipeline.metricEndpoint to be configured.
+                            type: boolean
+                          vectorAgent:
+                            description: |-
+                              VectorAgent enables automatic installation of the Vector log/metric collector.
+                              Requires pipeline.logEndpoint to be configured.
+                            type: boolean
+                        type: object
+                      logs:
+                        description: Logs configures default log collection settings.
+                        properties:
+                          journald:
+                            description: Journald enables collection of systemd journal
+                              logs.
+                            type: boolean
+                          kubernetesEvents:
+                            description: KubernetesEvents enables collection of Kubernetes
+                              events.
+                            type: boolean
+                          podLogs:
+                            description: PodLogs enables collection of container stdout/stderr
+                              logs.
+                            type: boolean
+                        type: object
+                      metrics:
+                        description: Metrics configures default metric collection
+                          settings.
+                        properties:
+                          enabled:
+                            description: Enabled controls whether metrics collection
+                              is enabled by default.
+                            type: boolean
+                          retention:
+                            description: Retention is the Prometheus data retention
+                              period (e.g., "15d").
+                            type: string
+                        type: object
+                    type: object
+                  pipeline:
+                    description: Pipeline configures the centralized observability
+                      pipeline cluster.
+                    properties:
+                      clusterRef:
+                        description: ClusterRef references the TenantCluster serving
+                          as the observability pipeline.
+                        properties:
+                          name:
+                            description: Name is the name of the resource.
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace of the resource.
+                            minLength: 1
+                            type: string
+                        required:
+                        - name
+                        - namespace
+                        type: object
+                      logEndpoint:
+                        description: |-
+                          LogEndpoint is the Vector aggregator ingestion URL.
+                          Example: "http://vector-aggregator.vector.svc:9000"
+                        type: string
+                      metricEndpoint:
+                        description: MetricEndpoint is the optional remote-write endpoint
+                          for metrics.
+                        type: string
+                      traceEndpoint:
+                        description: |-
+                          TraceEndpoint is the optional OTLP endpoint for traces.
+                          Example: "tempo.tracing.svc:4317"
+                        type: string
+                    type: object
+                type: object
+              sshAuthorizedKey:
+                description: |-
+                  SSHAuthorizedKey is the default SSH public key injected into worker nodes
+                  for platform-level diagnostic access. Applied to non-Talos workers only.
+                  Can be overridden per-cluster via TenantCluster.spec.workers.machineTemplate.os.sshAuthorizedKey.
+                type: string
             type: object
           status:
             description: ButlerConfigStatus defines the observed state of ButlerConfig.
@@ -224,10 +595,59 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              controlPlaneExposureMode:
+                description: ControlPlaneExposureMode is the active control plane
+                  exposure mode.
+                enum:
+                - LoadBalancer
+                - Ingress
+                - Gateway
+                type: string
+              gitProvider:
+                description: GitProvider shows the status of the configured Git provider.
+                properties:
+                  connected:
+                    description: Connected indicates whether the provider credentials
+                      are valid.
+                    type: boolean
+                  lastValidated:
+                    description: LastValidated is when the credentials were last validated.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Message provides additional status information.
+                    type: string
+                  username:
+                    description: Username is the authenticated username (from token
+                      validation).
+                    type: string
+                type: object
+              observability:
+                description: Observability shows the status of platform observability.
+                properties:
+                  enrolledCount:
+                    description: EnrolledCount is the number of tenant clusters with
+                      observability agents installed.
+                    format: int32
+                    type: integer
+                  pipelineReady:
+                    description: PipelineReady indicates whether the observability
+                      pipeline cluster is healthy.
+                    type: boolean
+                  totalCount:
+                    description: TotalCount is the total number of tenant clusters.
+                    format: int32
+                    type: integer
+                type: object
               observedGeneration:
                 description: ObservedGeneration is the last observed generation.
                 format: int64
                 type: integer
+              tcpProxyRequired:
+                description: |-
+                  TCPProxyRequired indicates if tcp-proxy is auto-enabled for tenants.
+                  True when ControlPlaneExposureMode is Ingress or Gateway.
+                type: boolean
               teamCount:
                 description: TeamCount is the current number of Teams.
                 format: int32

--- a/internal/crds/butler.butlerlabs.dev_providerconfigs.yaml
+++ b/internal/crds/butler.butlerlabs.dev_providerconfigs.yaml
@@ -21,6 +21,14 @@ spec:
       jsonPath: .spec.provider
       name: Provider
       type: string
+    - description: Visibility scope
+      jsonPath: .spec.scope.type
+      name: Scope
+      type: string
+    - description: Provider ready
+      jsonPath: .status.ready
+      name: Ready
+      type: boolean
     - description: Configuration validated
       jsonPath: .status.validated
       name: Validated
@@ -56,6 +64,54 @@ spec:
           spec:
             description: ProviderConfigSpec defines the desired state of ProviderConfig.
             properties:
+              aws:
+                description: |-
+                  AWS contains AWS-specific configuration.
+                  Required when provider is "aws".
+                properties:
+                  region:
+                    description: Region is the AWS region.
+                    type: string
+                  securityGroupIDs:
+                    description: SecurityGroupIDs are the security group identifiers.
+                    items:
+                      type: string
+                    type: array
+                  subnetIDs:
+                    description: SubnetIDs are the subnet identifiers for VM placement.
+                    items:
+                      type: string
+                    type: array
+                  vpcID:
+                    description: VPCID is the VPC identifier.
+                    type: string
+                required:
+                - region
+                type: object
+              azure:
+                description: |-
+                  Azure contains Azure-specific configuration.
+                  Required when provider is "azure".
+                properties:
+                  location:
+                    description: Location is the Azure region.
+                    type: string
+                  resourceGroup:
+                    description: ResourceGroup is the Azure resource group.
+                    type: string
+                  subnetName:
+                    description: SubnetName is the subnet within the VNet.
+                    type: string
+                  subscriptionID:
+                    description: SubscriptionID is the Azure subscription ID.
+                    type: string
+                  vnetName:
+                    description: VNetName is the Azure Virtual Network name.
+                    type: string
+                required:
+                - resourceGroup
+                - subscriptionID
+                type: object
               credentialsRef:
                 description: |-
                   CredentialsRef references the Secret containing provider credentials.
@@ -63,6 +119,7 @@ spec:
                   - harvester: "kubeconfig" (Harvester kubeconfig)
                   - nutanix: "username", "password"
                   - proxmox: "username", "password" or "token"
+                  - gcp: "serviceAccountKey" (JSON service account key)
                 properties:
                   key:
                     description: |-
@@ -80,6 +137,60 @@ spec:
                     type: string
                 required:
                 - name
+                type: object
+              gcp:
+                description: |-
+                  GCP contains GCP-specific configuration.
+                  Required when provider is "gcp".
+                properties:
+                  image:
+                    description: |-
+                      Image is the specific image name to use.
+                      Takes precedence over ImageFamily.
+                    type: string
+                  imageFamily:
+                    description: |-
+                      ImageFamily is the image family to use (e.g., "ubuntu-2204-lts").
+                      Ignored if Image is specified.
+                    type: string
+                  imageProject:
+                    description: ImageProject is the GCP project containing the source
+                      image (e.g., "ubuntu-os-cloud").
+                    type: string
+                  machineType:
+                    description: MachineType is the default GCE machine type (e.g.,
+                      "n2-standard-4").
+                    type: string
+                  network:
+                    description: Network is the VPC network name.
+                    type: string
+                  projectID:
+                    description: ProjectID is the GCP project identifier.
+                    type: string
+                  region:
+                    description: Region is the GCP region (e.g., "us-central1").
+                    type: string
+                  serviceAccount:
+                    description: ServiceAccount is the GCE service account email for
+                      VM instances.
+                    type: string
+                  subnetwork:
+                    description: Subnetwork is the subnetwork name.
+                    type: string
+                  tags:
+                    description: Tags are network tags applied to VM instances for
+                      firewall rules.
+                    items:
+                      type: string
+                    type: array
+                  zone:
+                    description: |-
+                      Zone is the GCP compute zone (e.g., "us-central1-a").
+                      If not specified, defaults to "{region}-a".
+                    type: string
+                required:
+                - projectID
+                - region
                 type: object
               harvester:
                 description: |-
@@ -111,6 +222,123 @@ spec:
                     type: string
                 required:
                 - networkName
+                type: object
+              limits:
+                description: Limits defines resource limits enforced per-team on this
+                  provider.
+                properties:
+                  maxClustersPerTeam:
+                    description: MaxClustersPerTeam limits the number of clusters
+                      per team.
+                    format: int32
+                    minimum: 1
+                    type: integer
+                  maxNodesPerTeam:
+                    description: MaxNodesPerTeam limits the total nodes per team.
+                    format: int32
+                    minimum: 1
+                    type: integer
+                type: object
+              network:
+                description: Network configures IPAM and network settings for this
+                  provider.
+                properties:
+                  dnsServers:
+                    description: DNSServers are the DNS server addresses.
+                    items:
+                      type: string
+                    type: array
+                  gateway:
+                    description: Gateway is the network gateway address.
+                    type: string
+                  loadBalancer:
+                    description: LoadBalancer configures load balancer IP allocation
+                      defaults.
+                    properties:
+                      allocationMode:
+                        default: static
+                        description: |-
+                          AllocationMode controls how LB IPs are allocated to tenants.
+                          "static" pre-allocates a fixed block (DefaultPoolSize IPs).
+                          "elastic" starts small and grows/shrinks based on usage.
+                        enum:
+                        - static
+                        - elastic
+                        type: string
+                      defaultPoolSize:
+                        default: 8
+                        description: DefaultPoolSize is the default number of LB IPs
+                          per tenant in static mode.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      growthIncrement:
+                        default: 2
+                        description: GrowthIncrement is the number of IPs added per
+                          expansion in elastic mode.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      initialPoolSize:
+                        default: 2
+                        description: InitialPoolSize is the number of LB IPs initially
+                          allocated in elastic mode.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                    type: object
+                  mode:
+                    default: cloud
+                    description: |-
+                      Mode determines how IP addresses are managed.
+                      "ipam" uses NetworkPool-based automated allocation.
+                      "cloud" relies on the cloud provider's native networking.
+                    enum:
+                    - ipam
+                    - cloud
+                    type: string
+                  poolRefs:
+                    description: |-
+                      PoolRefs references NetworkPools for IPAM allocation, ordered by priority.
+                      Required when mode is "ipam". Allocator tries first pool, falls back to next if exhausted.
+                    items:
+                      description: PoolReference references a NetworkPool with a priority.
+                      properties:
+                        name:
+                          description: Name is the name of the NetworkPool.
+                          type: string
+                        priority:
+                          default: 0
+                          description: |-
+                            Priority determines allocation order (lower = higher priority).
+                            Pools at the same priority are tried in list order.
+                          format: int32
+                          type: integer
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  quotaPerTenant:
+                    description: QuotaPerTenant defines per-tenant network resource
+                      quotas.
+                    properties:
+                      maxLoadBalancerIPs:
+                        description: MaxLoadBalancerIPs limits the number of LB IPs
+                          per tenant.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      maxNodeIPs:
+                        description: MaxNodeIPs limits the number of node IPs per
+                          tenant.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                    type: object
+                  subnet:
+                    description: Subnet is the network name for VM placement (e.g.,
+                      "VM Network - VLAN 40").
+                    type: string
                 type: object
               nutanix:
                 description: |-
@@ -156,6 +384,9 @@ spec:
                 - harvester
                 - nutanix
                 - proxmox
+                - azure
+                - aws
+                - gcp
                 type: string
               proxmox:
                 description: |-
@@ -206,6 +437,32 @@ spec:
                 - nodes
                 - storage
                 type: object
+              scope:
+                description: |-
+                  Scope defines the visibility of this ProviderConfig.
+                  Platform-scoped providers are available to all teams.
+                  Team-scoped providers are restricted to a specific team.
+                properties:
+                  teamRef:
+                    description: |-
+                      TeamRef references the Team when type is "team".
+                      Required when type is "team".
+                    properties:
+                      name:
+                        description: Name is the name of the resource.
+                        minLength: 1
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type:
+                    default: platform
+                    description: Type is the scope type.
+                    enum:
+                    - platform
+                    - team
+                    type: string
+                type: object
             required:
             - credentialsRef
             - provider
@@ -213,6 +470,20 @@ spec:
           status:
             description: ProviderConfigStatus defines the observed state of ProviderConfig.
             properties:
+              capacity:
+                description: Capacity reports the available capacity of this provider.
+                properties:
+                  availableIPs:
+                    description: AvailableIPs is the number of available IPs across
+                      all pools.
+                    format: int32
+                    type: integer
+                  estimatedTenants:
+                    description: EstimatedTenants is the estimated number of tenants
+                      that can be provisioned.
+                    format: int32
+                    type: integer
+                type: object
               conditions:
                 description: Conditions represent the latest available observations
                   of the ProviderConfig's state.
@@ -274,6 +545,10 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              lastProbeTime:
+                description: LastProbeTime is the timestamp of the last health probe.
+                format: date-time
+                type: string
               lastValidationTime:
                 description: LastValidationTime is the timestamp of the last successful
                   validation.
@@ -283,6 +558,9 @@ spec:
                 description: ProviderVersion is the detected version of the infrastructure
                   provider.
                 type: string
+              ready:
+                description: Ready indicates overall readiness of the provider.
+                type: boolean
               validated:
                 description: Validated indicates whether the provider configuration
                   has been validated.

--- a/internal/crds/butler.butlerlabs.dev_tenantclusters.yaml
+++ b/internal/crds/butler.butlerlabs.dev_tenantclusters.yaml
@@ -207,7 +207,7 @@ spec:
                     type: object
                 type: object
               controlPlane:
-                description: ControlPlane configures the Kamaji-hosted control plane.
+                description: ControlPlane configures the Steward-hosted control plane.
                 properties:
                   certSANs:
                     description: |-
@@ -218,7 +218,7 @@ spec:
                     type: array
                   dataStoreRef:
                     description: |-
-                      DataStoreRef references the Kamaji DataStore to use.
+                      DataStoreRef references the Steward DataStore to use.
                       If not specified, the default DataStore is used.
                     properties:
                       name:
@@ -238,19 +238,221 @@ spec:
                     default: 1
                     description: |-
                       Replicas is the number of API server replicas.
-                      Kamaji manages high availability automatically.
+                      Steward manages high availability automatically.
                     format: int32
                     maximum: 3
                     minimum: 1
                     type: integer
+                  resources:
+                    description: |-
+                      Resources overrides platform-level control plane resource defaults from ButlerConfig.
+                      Per-component: if a component is set here, it fully replaces the ButlerConfig default
+                      for that component. Components not set here inherit from ButlerConfig.
+                    properties:
+                      apiServer:
+                        description: APIServer resource requirements.
+                        properties:
+                          limits:
+                            description: Limits describes the maximum resources allowed.
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: CPU resource (e.g., "100m", "1", "2").
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Memory resource (e.g., "128Mi", "1Gi").
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            description: Requests describes the minimum resources
+                              required.
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: CPU resource (e.g., "100m", "1", "2").
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Memory resource (e.g., "128Mi", "1Gi").
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
+                      controllerManager:
+                        description: ControllerManager resource requirements.
+                        properties:
+                          limits:
+                            description: Limits describes the maximum resources allowed.
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: CPU resource (e.g., "100m", "1", "2").
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Memory resource (e.g., "128Mi", "1Gi").
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            description: Requests describes the minimum resources
+                              required.
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: CPU resource (e.g., "100m", "1", "2").
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Memory resource (e.g., "128Mi", "1Gi").
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
+                      scheduler:
+                        description: Scheduler resource requirements.
+                        properties:
+                          limits:
+                            description: Limits describes the maximum resources allowed.
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: CPU resource (e.g., "100m", "1", "2").
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Memory resource (e.g., "128Mi", "1Gi").
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            description: Requests describes the minimum resources
+                              required.
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: CPU resource (e.g., "100m", "1", "2").
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Memory resource (e.g., "128Mi", "1Gi").
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
+                    type: object
                   serviceType:
-                    default: LoadBalancer
-                    description: ServiceType for the control plane endpoint.
+                    description: |-
+                      ServiceType for the control plane endpoint.
+                      If not specified, inherits from ButlerConfig.spec.controlPlaneExposure.mode.
+                      Only set this to override the platform-level setting for this specific cluster.
                     enum:
                     - LoadBalancer
                     - NodePort
                     - ClusterIP
                     type: string
+                type: object
+              infrastructureOverride:
+                description: |-
+                  InfrastructureOverride allows overriding provider-specific settings.
+                  These take precedence over ProviderConfig defaults.
+                properties:
+                  gcp:
+                    description: GCP contains GCP-specific overrides.
+                    properties:
+                      image:
+                        description: Image overrides the default image.
+                        type: string
+                      imageFamily:
+                        description: ImageFamily overrides the default image family.
+                        type: string
+                      machineType:
+                        description: MachineType overrides the default GCE machine
+                          type.
+                        type: string
+                      subnetwork:
+                        description: Subnetwork overrides the default subnetwork.
+                        type: string
+                      zone:
+                        description: Zone overrides the default GCP compute zone.
+                        type: string
+                    type: object
+                  harvester:
+                    description: Harvester contains Harvester-specific overrides.
+                    properties:
+                      imageName:
+                        description: 'ImageName is the VM image to use (format: namespace/name).'
+                        type: string
+                      namespace:
+                        description: Namespace is the Harvester namespace for VMs.
+                        type: string
+                      networkName:
+                        description: 'NetworkName is the Harvester network to use
+                          (format: namespace/name).'
+                        type: string
+                    type: object
+                  nutanix:
+                    description: Nutanix contains Nutanix-specific overrides.
+                    properties:
+                      clusterUUID:
+                        description: ClusterUUID is the Nutanix cluster UUID.
+                        type: string
+                      imageUUID:
+                        description: ImageUUID is the Nutanix image UUID.
+                        type: string
+                      storageContainerUUID:
+                        description: StorageContainerUUID is the Nutanix storage container
+                          UUID.
+                        type: string
+                      subnetUUID:
+                        description: SubnetUUID is the Nutanix subnet UUID.
+                        type: string
+                    type: object
+                  proxmox:
+                    description: Proxmox contains Proxmox-specific overrides.
+                    properties:
+                      node:
+                        description: Node is the Proxmox node to deploy VMs on.
+                        type: string
+                      storage:
+                        description: Storage is the Proxmox storage to use.
+                        type: string
+                      templateID:
+                        description: TemplateID is the VM template ID.
+                        type: integer
+                    type: object
                 type: object
               kubernetesVersion:
                 description: KubernetesVersion is the target Kubernetes version.
@@ -271,9 +473,17 @@ spec:
               networking:
                 description: Networking configures cluster networking.
                 properties:
+                  lbPoolSize:
+                    description: |-
+                      LBPoolSize overrides the default load balancer pool size from the provider.
+                      Only used when the provider has network.mode=ipam.
+                    format: int32
+                    minimum: 1
+                    type: integer
                   loadBalancerPool:
-                    description: LoadBalancerPool defines the IP pool for LoadBalancer
-                      services.
+                    description: |-
+                      LoadBalancerPool defines the IP pool for LoadBalancer services.
+                      When IPAM is active, this is populated automatically from IPAllocation.
                     properties:
                       end:
                         description: End is the last IP in the pool.
@@ -298,10 +508,16 @@ spec:
                 description: |-
                   ProviderConfigRef references the ProviderConfig for infrastructure.
                   If not specified, defaults are used (Team's or platform's).
+                  Namespace defaults to butler-system if not specified.
                 properties:
                   name:
-                    description: Name is the name of the resource.
+                    description: Name is the name of the ProviderConfig resource.
                     minLength: 1
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace is the namespace of the ProviderConfig resource.
+                      If not specified, the namespace of the referencing resource is used.
                     type: string
                 required:
                 - name
@@ -355,12 +571,47 @@ spec:
                               ImageRef references a specific image to use.
                               Overrides Type and Version if specified.
                             type: string
+                          schematicID:
+                            description: |-
+                              SchematicID references a Butler Image Factory schematic.
+                              When set with AutoSync enabled, Butler automatically syncs the
+                              factory-built image to the target provider before VM creation.
+                            type: string
+                          sshAuthorizedKey:
+                            description: |-
+                              SSHAuthorizedKey overrides the platform default SSH public key for this cluster's workers.
+                              Only applies to non-Talos OS types (Flatcar, Bottlerocket).
+                              If empty, falls back to ButlerConfig.spec.sshAuthorizedKey.
+                            type: string
+                          talos:
+                            description: |-
+                              Talos provides Talos-specific worker node configuration.
+                              Required when type is "talos".
+                            properties:
+                              installDisk:
+                                default: /dev/vda
+                                description: InstallDisk is the disk where Talos will
+                                  be installed.
+                                type: string
+                              installerImage:
+                                description: |-
+                                  InstallerImage is the Talos installer image
+                                  (e.g., factory.talos.dev/installer/<schematic>:v1.9.3).
+                                type: string
+                              version:
+                                default: v1.9.3
+                                description: Version is the Talos version.
+                                type: string
+                            type: object
                           type:
                             default: rocky
                             description: Type is the OS type.
                             enum:
                             - rocky
                             - flatcar
+                            - talos
+                            - kairos
+                            - bottlerocket
                             type: string
                           version:
                             default: "9.5"
@@ -375,6 +626,54 @@ spec:
                     type: integer
                 required:
                 - replicas
+                type: object
+              workspaces:
+                description: |-
+                  Workspaces configures cloud development environments on this cluster.
+                  When enabled, users can create Workspace resources that provision pods
+                  with SSH access in the tenant cluster's "workspaces" namespace.
+                properties:
+                  autoDeleteAfter:
+                    default: 720h
+                    description: |-
+                      AutoDeleteAfter deletes stopped workspaces after this duration.
+                      Prevents PVC sprawl. 0 means never auto-delete.
+                    type: string
+                  defaultImage:
+                    default: ghcr.io/butlerdotdev/workspace-base:latest
+                    description: DefaultImage is the default workspace image if user
+                      doesn't specify one.
+                    type: string
+                  enabled:
+                    default: false
+                    description: Enabled allows workspace creation on this cluster.
+                    type: boolean
+                  maxWorkspaces:
+                    default: 20
+                    description: MaxWorkspaces per cluster. 0 means unlimited.
+                    format: int32
+                    type: integer
+                  resourceQuota:
+                    description: ResourceQuota for the workspaces namespace in the
+                      tenant cluster.
+                    properties:
+                      maxCPU:
+                        default: "16"
+                        description: MaxCPU total across all workspaces in this cluster.
+                        type: string
+                      maxMemory:
+                        default: 32Gi
+                        description: MaxMemory total across all workspaces in this
+                          cluster.
+                        type: string
+                      maxStorage:
+                        default: 500Gi
+                        description: MaxStorage total across all workspace PVCs in
+                          this cluster.
+                        type: string
+                    type: object
+                required:
+                - enabled
                 type: object
             required:
             - kubernetesVersion
@@ -446,6 +745,28 @@ spec:
               controlPlaneEndpoint:
                 description: ControlPlaneEndpoint is the API server endpoint.
                 type: string
+              imageSyncRef:
+                description: ImageSyncRef references the ImageSync resource for this
+                  cluster's OS image.
+                properties:
+                  name:
+                    description: Name is the name of the resource.
+                    minLength: 1
+                    type: string
+                required:
+                - name
+                type: object
+              ipAllocationRef:
+                description: IPAllocationRef references the node IP allocation from
+                  IPAM.
+                properties:
+                  name:
+                    description: Name is the name of the resource.
+                    minLength: 1
+                    type: string
+                required:
+                - name
+                type: object
               kubeconfigSecretRef:
                 description: KubeconfigSecretRef references the Secret containing
                   the kubeconfig.
@@ -461,6 +782,17 @@ spec:
                 description: LastTransitionTime is when the phase last changed.
                 format: date-time
                 type: string
+              lbAllocationRef:
+                description: LBAllocationRef references the load balancer IP allocation
+                  from IPAM.
+                properties:
+                  name:
+                    description: Name is the name of the resource.
+                    minLength: 1
+                    type: string
+                required:
+                - name
+                type: object
               observedGeneration:
                 description: ObservedGeneration is the last observed generation.
                 format: int64
@@ -540,9 +872,17 @@ spec:
                 - Failed
                 type: string
               tenantNamespace:
-                description: TenantNamespace is the namespace containing CAPI/Kamaji
+                description: TenantNamespace is the namespace containing CAPI/Steward
                   resources.
                 type: string
+              workerNodesDesired:
+                description: WorkerNodesDesired is the desired count of worker nodes
+                format: int32
+                type: integer
+              workerNodesReady:
+                description: WorkerNodesReady is the count of ready worker nodes
+                format: int32
+                type: integer
             type: object
         type: object
     served: true

--- a/internal/talos/client.go
+++ b/internal/talos/client.go
@@ -96,6 +96,15 @@ func (c *Client) GenerateConfig(ctx context.Context, opts controller.TalosConfig
 	// Disable kube-proxy (Cilium handles this)
 	args = append(args, "--config-patch", `[{"op": "add", "path": "/cluster/proxy", "value": {"disabled": true}}]`)
 
+	// Set cloud platform for metadata discovery and cloud-init.
+	// Without this, Talos defaults to the metal platform which does not
+	// query cloud instance metadata services.
+	if opts.Platform != "" {
+		args = append(args, "--config-patch", fmt.Sprintf(
+			`[{"op": "add", "path": "/machine/install/platform", "value": "%s"}]`,
+			opts.Platform))
+	}
+
 	// Allow scheduling on control planes for single-node clusters
 	// This enables workloads to run on the single control plane node
 	if opts.AllowSchedulingOnControlPlanes {

--- a/internal/talos/client.go
+++ b/internal/talos/client.go
@@ -103,6 +103,31 @@ func (c *Client) GenerateConfig(ctx context.Context, opts controller.TalosConfig
 	// but management clusters don't need CCM. Tenant clusters on cloud
 	// providers get --cloud-provider=external via CAPI machine templates.
 
+	// Add certSANs for control plane IPs and VIP so the Talos API
+	// certificate includes IPs used for remote connections. On cloud
+	// providers, nodes only see their internal IP but connections arrive
+	// via external/NAT IPs that must be in the certificate SANs.
+	var certSANs []string
+	seen := make(map[string]bool)
+	if opts.ControlPlaneVIP != "" {
+		certSANs = append(certSANs, opts.ControlPlaneVIP)
+		seen[opts.ControlPlaneVIP] = true
+	}
+	for _, ip := range opts.ControlPlaneIPs {
+		if !seen[ip] {
+			certSANs = append(certSANs, ip)
+			seen[ip] = true
+		}
+	}
+	if len(certSANs) > 0 {
+		var quoted []string
+		for _, san := range certSANs {
+			quoted = append(quoted, fmt.Sprintf(`"%s"`, san))
+		}
+		sansJSON := "[" + strings.Join(quoted, ",") + "]"
+		args = append(args, "--config-patch", fmt.Sprintf(`[{"op": "add", "path": "/machine/certSANs", "value": %s}]`, sansJSON))
+	}
+
 	// Allow scheduling on control planes for single-node clusters
 	// This enables workloads to run on the single control plane node
 	if opts.AllowSchedulingOnControlPlanes {
@@ -205,10 +230,10 @@ func (c *Client) Bootstrap(ctx context.Context, nodeIP string) error {
 	logger := log.FromContext(ctx)
 
 	var lastErr error
-	for attempt := 0; attempt < 3; attempt++ {
+	for attempt := 0; attempt < 5; attempt++ {
 		if attempt > 0 {
-			logger.Info("Retrying bootstrap after clock skew error", "attempt", attempt+1)
-			time.Sleep(5 * time.Second)
+			logger.Info("Retrying bootstrap", "attempt", attempt+1)
+			time.Sleep(10 * time.Second)
 		}
 
 		args := []string{
@@ -232,8 +257,11 @@ func (c *Client) Bootstrap(ctx context.Context, nodeIP string) error {
 				logger.Info("Cluster already bootstrapped")
 				return nil
 			}
-			// Retry on clock skew / cert not yet valid errors
-			if strings.Contains(outputStr, "certificate has expired or is not yet valid") {
+			// Retry on transient errors (clock skew, node still initializing)
+			if strings.Contains(outputStr, "certificate has expired or is not yet valid") ||
+				strings.Contains(outputStr, "bootstrap is not available yet") ||
+				strings.Contains(outputStr, "connection refused") ||
+				strings.Contains(outputStr, "connection reset") {
 				lastErr = fmt.Errorf("talosctl bootstrap failed: %w, output: %s", err, outputStr)
 				continue
 			}

--- a/internal/talos/client.go
+++ b/internal/talos/client.go
@@ -103,6 +103,12 @@ func (c *Client) GenerateConfig(ctx context.Context, opts controller.TalosConfig
 		args = append(args, "--config-patch", fmt.Sprintf(
 			`[{"op": "add", "path": "/machine/install/platform", "value": "%s"}]`,
 			opts.Platform))
+
+		// CCM requires kubelet to start with --cloud-provider=external.
+		// Without this, kubelet registers nodes as bare metal and CCM
+		// cannot manage node lifecycle or provision LoadBalancer services.
+		args = append(args, "--config-patch",
+			`[{"op": "add", "path": "/machine/kubelet/extraArgs", "value": {"cloud-provider": "external"}}]`)
 	}
 
 	// Allow scheduling on control planes for single-node clusters

--- a/internal/talos/client.go
+++ b/internal/talos/client.go
@@ -96,20 +96,12 @@ func (c *Client) GenerateConfig(ctx context.Context, opts controller.TalosConfig
 	// Disable kube-proxy (Cilium handles this)
 	args = append(args, "--config-patch", `[{"op": "add", "path": "/cluster/proxy", "value": {"disabled": true}}]`)
 
-	// Set cloud platform for metadata discovery and cloud-init.
-	// Without this, Talos defaults to the metal platform which does not
-	// query cloud instance metadata services.
-	if opts.Platform != "" {
-		args = append(args, "--config-patch", fmt.Sprintf(
-			`[{"op": "add", "path": "/machine/install/platform", "value": "%s"}]`,
-			opts.Platform))
-
-		// CCM requires kubelet to start with --cloud-provider=external.
-		// Without this, kubelet registers nodes as bare metal and CCM
-		// cannot manage node lifecycle or provision LoadBalancer services.
-		args = append(args, "--config-patch",
-			`[{"op": "add", "path": "/machine/kubelet/extraArgs", "value": {"cloud-provider": "external"}}]`)
-	}
+	// Cloud platforms: Talos auto-detects the platform from the VM environment
+	// (GCP metadata service, AWS IMDS, Azure IMDS). No config patch needed.
+	// Note: --cloud-provider=external is NOT set for management clusters.
+	// It adds an "uninitialized" taint that blocks all pods until CCM runs,
+	// but management clusters don't need CCM. Tenant clusters on cloud
+	// providers get --cloud-provider=external via CAPI machine templates.
 
 	// Allow scheduling on control planes for single-node clusters
 	// This enables workloads to run on the single control plane node


### PR DESCRIPTION
## Summary
- Add GCP, AWS, and Azure provider support to bootstrap controller
- Cloud-generic addon installation: skip kube-vip and MetalLB for cloud providers, install CAPI providers (CAPG/CAPA/CAPZ) with variable substitution
- Install butler-console and butler-server as management cluster addons
- Ensure steward-system namespace exists before console chart install
- Fix Dockerfile for parent context Docker builds (local dev)
- Remove cloud-provider=external from management cluster bootstrap (avoids uninitialized taint deadlock)
- Fix substituteDefaults() to skip unrecognized patterns instead of breaking
- Gate non-fatal infra provider install on cloud providers only (on-prem failures remain fatal)
- Guard against empty control plane endpoint generating invalid URL
- Sync embedded CRDs from butler-api

## Test plan
- [x] `CGO_ENABLED=0 go vet ./internal/...` passes
- [x] E2E: GCP bootstrap completes to Ready with all pods healthy
- [x] butler-console accessible via port-forward with working admin login
- [ ] On-prem (Harvester) bootstrap still works with kube-vip/MetalLB