### PR TITLE
fix: remove dead code and fix error logging in bootstrap controller

### DIFF
--- a/internal/addons/installer.go
+++ b/internal/addons/installer.go
@@ -766,53 +766,6 @@ func (i *Installer) InstallGatewayAPI(ctx context.Context, kubeconfig []byte, ve
 	return nil
 }
 
-// // InstallStewardCRDs installs Steward CRDs separately (optional - main chart includes CRDs)
-// func (i *Installer) InstallStewardCRDs(ctx context.Context, kubeconfig []byte, version string) error {
-// 	logger := log.FromContext(ctx)
-// 	kubeconfigPath, cleanup, err := i.writeKubeconfig(kubeconfig)
-// 	if err != nil {
-// 		return err
-// 	}
-// 	defer cleanup()
-//
-// 	if version == "" {
-// 		version = "0.1.0"
-// 	}
-//
-// 	logger.Info("Installing Steward CRDs", "version", version)
-//
-// 	// Install Steward CRDs via OCI registry
-// 	args := []string{
-// 		"upgrade", "--install", "steward-crds",
-// 		"oci://ghcr.io/butlerdotdev/charts/steward-crds",
-// 		"--namespace", "steward-system",
-// 		"--create-namespace",
-// 		"--version", version,
-// 		"--wait",
-// 		"--timeout", "2m",
-// 	}
-//
-// 	if err := i.runHelm(ctx, kubeconfigPath, args...); err != nil {
-// 		return fmt.Errorf("failed to install Steward CRDs: %w", err)
-// 	}
-//
-// 	// Wait for CRDs to be established
-// 	crds := []string{
-// 		"tenantcontrolplanes.steward.butlerlabs.dev",
-// 		"datastores.steward.butlerlabs.dev",
-// 	}
-//
-// 	for _, crd := range crds {
-// 		if err := i.runKubectl(ctx, kubeconfigPath, "wait", "--for=condition=Established",
-// 			"crd", crd, "--timeout=60s"); err != nil {
-// 			logger.Info("Steward CRD wait timeout (may already be ready)", "crd", crd)
-// 		}
-// 	}
-//
-// 	logger.Info("Steward CRDs installed successfully")
-// 	return nil
-// }
-
 // InstallSteward installs Steward for hosted control planes (replaces Kamaji)
 func (i *Installer) InstallSteward(ctx context.Context, kubeconfig []byte, version string) error {
 	logger := log.FromContext(ctx)
@@ -840,7 +793,7 @@ func (i *Installer) InstallSteward(ctx context.Context, kubeconfig []byte, versi
 		"--namespace", "steward-system",
 		"--version", version,
 		"--set", "image.repository=ghcr.io/butlerdotdev/steward",
-		"--set", "image.tag=v0.1.0-alpha",
+		"--set", fmt.Sprintf("image.tag=%s", version),
 		"--set", "steward-etcd.deploy=true",
 		"--wait",
 		"--timeout", "5m",
@@ -2153,78 +2106,4 @@ func (i *Installer) getConsoleURLFromSpec(ctx context.Context, kubeconfigPath st
 	}
 
 	return "kubectl port-forward -n butler-system svc/butler-console-frontend 3000:80"
-}
-
-// getConsoleURL determines the URL to access the console
-func (i *Installer) getConsoleURL(ctx context.Context, kubeconfigPath string, cfg ConsoleConfig) string {
-	logger := log.FromContext(ctx)
-
-	// If ingress is configured, use the ingress host
-	if cfg.Ingress.Enabled && cfg.Ingress.Host != "" {
-		scheme := "http"
-		if cfg.Ingress.TLS {
-			scheme = "https"
-		}
-		return fmt.Sprintf("%s://%s", scheme, cfg.Ingress.Host)
-	}
-
-	// Try to get LoadBalancer IP from frontend service
-	cmd := exec.CommandContext(ctx, i.KubectlPath,
-		"--kubeconfig", kubeconfigPath,
-		"--insecure-skip-tls-verify",
-		"get", "svc", "butler-console-frontend",
-		"-n", "butler-system",
-		"-o", "jsonpath={.status.loadBalancer.ingress[0].ip}",
-	)
-	if i.NodeIP != "" {
-		cmd.Args = append(cmd.Args, "--server", fmt.Sprintf("https://%s:6443", i.NodeIP))
-	}
-
-	output, err := cmd.Output()
-	if err == nil && len(output) > 0 {
-		return fmt.Sprintf("http://%s", string(output))
-	}
-
-	// Fallback: try to get external IP
-	cmd = exec.CommandContext(ctx, i.KubectlPath,
-		"--kubeconfig", kubeconfigPath,
-		"--insecure-skip-tls-verify",
-		"get", "svc", "butler-console-frontend",
-		"-n", "butler-system",
-		"-o", "jsonpath={.spec.externalIPs[0]}",
-	)
-	if i.NodeIP != "" {
-		cmd.Args = append(cmd.Args, "--server", fmt.Sprintf("https://%s:6443", i.NodeIP))
-	}
-
-	output, err = cmd.Output()
-	if err == nil && len(output) > 0 {
-		return fmt.Sprintf("http://%s", string(output))
-	}
-
-	// Last resort: use port-forward instruction
-	logger.Info("Could not determine console external URL, will require port-forward")
-	return "kubectl port-forward -n butler-system svc/butler-console-frontend 3000:80"
-}
-
-// ConsoleConfig is passed to InstallConsole
-// This mirrors the config from orchestrator package
-type ConsoleConfig struct {
-	Enabled bool
-	Version string
-	Ingress ConsoleIngressConfig
-	Auth    ConsoleAuthConfig
-}
-
-type ConsoleIngressConfig struct {
-	Enabled       bool
-	Host          string
-	ClassName     string
-	TLS           bool
-	TLSSecretName string
-}
-
-type ConsoleAuthConfig struct {
-	AdminPassword string
-	JWTSecret     string
 }

--- a/internal/controller/clusterbootstrap_controller.go
+++ b/internal/controller/clusterbootstrap_controller.go
@@ -104,9 +104,8 @@ type AddonInstallerInterface interface {
 	InstallMetalLB(ctx context.Context, kubeconfig []byte, addressPool string, topology string) error
 	InstallCloudControllerManager(ctx context.Context, kubeconfig []byte, provider string) error
 	InstallTraefik(ctx context.Context, kubeconfig []byte, version string) error
-	InstallGatewayAPI(ctx context.Context, kubeconfig []byte, version string) error // NEW: Gateway API CRDs
-	// InstallStewardCRDs(ctx context.Context, kubeconfig []byte, version string) error // NEW: Steward CRDs (optional)
-	InstallSteward(ctx context.Context, kubeconfig []byte, version string) error // NEW: Replaces InstallKamaji
+	InstallGatewayAPI(ctx context.Context, kubeconfig []byte, version string) error
+	InstallSteward(ctx context.Context, kubeconfig []byte, version string) error
 	InstallFlux(ctx context.Context, kubeconfig []byte) error
 	InstallButler(ctx context.Context, kubeconfig []byte) error
 	InstallButlerCRDs(ctx context.Context, kubeconfig []byte, version string) error
@@ -793,7 +792,7 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 
 		r.setAddonInstalled(cb, "kube-vip")
 		if err := r.Status().Update(ctx, cb); err != nil {
-			logger.Info("Failed to update status after kube-vip step", "error", err)
+			logger.Error(err, "Failed to update status after kube-vip step")
 		}
 	}
 
@@ -814,7 +813,7 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 			r.setAddonInstalled(cb, "cilium")
 			logger.Info("Cilium installed successfully")
 			if err := r.Status().Update(ctx, cb); err != nil {
-				logger.Info("Failed to update status after Cilium install", "error", err)
+				logger.Error(err, "Failed to update status after Cilium install")
 			}
 		}
 	}
@@ -846,7 +845,7 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 			r.setAddonInstalled(cb, "cert-manager")
 			logger.Info("cert-manager installed successfully")
 			if err := r.Status().Update(ctx, cb); err != nil {
-				logger.Info("Failed to update status after cert-manager install", "error", err)
+				logger.Error(err, "Failed to update status after cert-manager install")
 			}
 		}
 	}
@@ -873,7 +872,7 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 			r.setAddonInstalled(cb, "longhorn")
 			logger.Info("Longhorn installed successfully", "replicaCount", replicas)
 			if err := r.Status().Update(ctx, cb); err != nil {
-				logger.Info("Failed to update status after Longhorn install", "error", err)
+				logger.Error(err, "Failed to update status after Longhorn install")
 			}
 		}
 	}
@@ -891,7 +890,7 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 			r.setAddonInstalled(cb, "metallb")
 			logger.Info("MetalLB installed successfully")
 			if err := r.Status().Update(ctx, cb); err != nil {
-				logger.Info("Failed to update status after MetalLB install", "error", err)
+				logger.Error(err, "Failed to update status after MetalLB install")
 			}
 		}
 	}
@@ -920,7 +919,7 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 
 		r.setAddonInstalled(cb, "traefik")
 		if err := r.Status().Update(ctx, cb); err != nil {
-			logger.Info("Failed to update status after Traefik step", "error", err)
+			logger.Error(err, "Failed to update status after Traefik step")
 		}
 	}
 
@@ -935,33 +934,11 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 		r.setAddonInstalled(cb, "gateway-api")
 		logger.Info("Gateway API CRDs installed successfully")
 		if err := r.Status().Update(ctx, cb); err != nil {
-			logger.Info("Failed to update status after Gateway API install", "error", err)
+			logger.Error(err, "Failed to update status after Gateway API install")
 		}
 	}
 
-	// 7b. Steward CRDs - install before controller to ensure CRDs exist
-	// if addons.ControlPlaneProvider == nil || isAddonEnabled(addons.ControlPlaneProvider.Enabled) {
-	// 	if !r.isAddonInstalled(cb, "steward-crds") {
-	// 		logger.Info("Installing Steward CRDs")
-	// 		version := ""
-	// 		if addons.ControlPlaneProvider != nil && addons.ControlPlaneProvider.Version != "" {
-	// 			version = addons.ControlPlaneProvider.Version
-	// 		}
-	//
-	// 		if err := r.AddonInstaller.InstallStewardCRDs(ctx, kubeconfig, version); err != nil {
-	// 			logger.Error(err, "Failed to install Steward CRDs")
-	// 			return ctrl.Result{RequeueAfter: requeueShort}, nil
-	// 		}
-	//
-	// 		r.setAddonInstalled(cb, "steward-crds")
-	// 		logger.Info("Steward CRDs installed successfully")
-	// 		if err := r.Status().Update(ctx, cb); err != nil {
-	// 			logger.Info("Failed to update status after Steward CRDs install", "error", err)
-	// 		}
-	// 	}
-	// }
-
-	// 7c. Steward - hosted control planes (replaces Kamaji)
+	// 7b. Steward - hosted control planes (replaces Kamaji)
 	if addons.ControlPlaneProvider == nil || isAddonEnabled(addons.ControlPlaneProvider.Enabled) {
 		if !r.isAddonInstalled(cb, "steward") {
 			logger.Info("Installing Steward")
@@ -978,7 +955,7 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 			r.setAddonInstalled(cb, "steward")
 			logger.Info("Steward installed successfully")
 			if err := r.Status().Update(ctx, cb); err != nil {
-				logger.Info("Failed to update status after Steward install", "error", err)
+				logger.Error(err, "Failed to update status after Steward install")
 			}
 		}
 	}
@@ -1013,7 +990,7 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 			r.setAddonInstalled(cb, "capi")
 			logger.Info("CAPI installed successfully")
 			if err := r.Status().Update(ctx, cb); err != nil {
-				logger.Info("Failed to update status after CAPI install", "error", err)
+				logger.Error(err, "Failed to update status after CAPI install")
 			}
 		}
 	}
@@ -1031,7 +1008,7 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 			r.setAddonInstalled(cb, "flux")
 			logger.Info("Flux installed successfully")
 			if err := r.Status().Update(ctx, cb); err != nil {
-				logger.Info("Failed to update status after Flux install", "error", err)
+				logger.Error(err, "Failed to update status after Flux install")
 			}
 		}
 	}
@@ -1049,7 +1026,7 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 			r.setAddonInstalled(cb, "butler-crds")
 			logger.Info("Butler CRDs installed successfully")
 			if err := r.Status().Update(ctx, cb); err != nil {
-				logger.Info("Failed to update status after Butler CRDs install", "error", err)
+				logger.Error(err, "Failed to update status after Butler CRDs install")
 			}
 		}
 	}
@@ -1080,7 +1057,7 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 			r.setAddonInstalled(cb, "butler-addons")
 			logger.Info("Butler addon definitions installed successfully")
 			if err := r.Status().Update(ctx, cb); err != nil {
-				logger.Info("Failed to update status after Butler addons install", "error", err)
+				logger.Error(err, "Failed to update status after Butler addons install")
 			}
 		}
 	}
@@ -1101,7 +1078,7 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 			r.setAddonInstalled(cb, "butler-controller")
 			logger.Info("Butler Controller installed successfully")
 			if err := r.Status().Update(ctx, cb); err != nil {
-				logger.Info("Failed to update status after Butler Controller install", "error", err)
+				logger.Error(err, "Failed to update status after Butler Controller install")
 			}
 		}
 	}
@@ -1118,7 +1095,7 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 		r.setAddonInstalled(cb, "butler")
 		logger.Info("Butler installed successfully")
 		if err := r.Status().Update(ctx, cb); err != nil {
-			logger.Info("Failed to update status after Butler install", "error", err)
+			logger.Error(err, "Failed to update status after Butler install")
 		}
 	}
 
@@ -1138,7 +1115,7 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 			r.setAddonInstalled(cb, "butler-config-exposure")
 			logger.Info("ButlerConfig exposure settings written successfully")
 			if err := r.Status().Update(ctx, cb); err != nil {
-				logger.Info("Failed to update status after ButlerConfig write", "error", err)
+				logger.Error(err, "Failed to update status after ButlerConfig write")
 			}
 		} else {
 			// No exposure config specified, skip but mark as done
@@ -1163,7 +1140,7 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 			r.setAddonInstalled(cb, "butler-console")
 			logger.Info("Butler Console installed successfully", "url", consoleURL)
 			if err := r.Status().Update(ctx, cb); err != nil {
-				logger.Info("Failed to update status after Console install", "error", err)
+				logger.Error(err, "Failed to update status after Console install")
 			}
 		}
 	}
@@ -1649,7 +1626,7 @@ func (r *ClusterBootstrapReconciler) reconcileButlerConfig(ctx context.Context, 
 	bc.Status.TCPProxyRequired = cb.IsTCPProxyRequired()
 
 	if err := targetClient.Status().Update(ctx, bc); err != nil {
-		logger.Info("Failed to update ButlerConfig status", "error", err)
+		logger.Error(err, "Failed to update ButlerConfig status")
 		// Don't fail on status update error
 	}
 


### PR DESCRIPTION
## Summary

- Remove dead functions and types from `internal/addons/installer.go`: unused `getConsoleURL()`, `ConsoleConfig`, `ConsoleIngressConfig`, `ConsoleAuthConfig` types, and commented-out `InstallStewardCRDs()` block
- Remove commented-out Steward CRDs reconciliation block from `internal/controller/clusterbootstrap_controller.go`
- Fix hardcoded Steward image tag `v0.1.0-alpha` to use the version parameter passed to `InstallSteward()`
- Change 16 status update failure log calls from `logger.Info()` to `logger.Error()` for proper error visibility

## Test plan

- [ ] `CGO_ENABLED=0 go vet ./internal/...` passes (verified locally)
- [ ] No compilation errors from removed dead code
- [ ] Steward installation uses dynamic version tag instead of hardcoded string
- [ ] Error logs for status update failures are visible at Error level