### PR TITLE
fix: cloud bootstrap improvements for AWS HA

### DIFF
--- a/internal/addons/installer.go
+++ b/internal/addons/installer.go
@@ -776,7 +776,7 @@ func (i *Installer) InstallSteward(ctx context.Context, kubeconfig []byte, versi
 	defer cleanup()
 
 	if version == "" {
-		version = "0.1.0"
+		version = "0.3.0"
 	}
 
 	logger.Info("Installing Steward", "version", version)

--- a/internal/controller/clusterbootstrap_controller.go
+++ b/internal/controller/clusterbootstrap_controller.go
@@ -1920,25 +1920,34 @@ func (r *ClusterBootstrapReconciler) updateLoadBalancerTargets(ctx context.Conte
 		if m.IPAddress == "" {
 			continue
 		}
-		targets = append(targets, butlerv1alpha1.LoadBalancerTarget{
+		target := butlerv1alpha1.LoadBalancerTarget{
 			IP:           m.IPAddress,
 			InstanceName: m.Name,
-		})
+		}
+		// Look up MachineRequest to get provider-specific instance ID
+		// (e.g., EC2 instance ID for AWS NLB target registration).
+		mr := &butlerv1alpha1.MachineRequest{}
+		if err := r.Get(ctx, client.ObjectKey{Name: m.Name, Namespace: cb.Namespace}, mr); err == nil {
+			if mr.Status.ProviderID != "" {
+				target.InstanceID = mr.Status.ProviderID
+			}
+		}
+		targets = append(targets, target)
 	}
 
 	if len(targets) == 0 {
 		return nil
 	}
 
-	// Only update if targets changed
+	// Only update if targets changed (check IP and InstanceID)
 	if len(targets) == len(lbr.Spec.Targets) {
 		changed := false
-		existing := make(map[string]bool)
+		existing := make(map[string]string) // IP -> InstanceID
 		for _, t := range lbr.Spec.Targets {
-			existing[t.IP] = true
+			existing[t.IP] = t.InstanceID
 		}
 		for _, t := range targets {
-			if !existing[t.IP] {
+			if existingID, ok := existing[t.IP]; !ok || existingID != t.InstanceID {
 				changed = true
 				break
 			}

--- a/internal/controller/clusterbootstrap_controller.go
+++ b/internal/controller/clusterbootstrap_controller.go
@@ -511,11 +511,13 @@ func (r *ClusterBootstrapReconciler) reconcileConfiguringTalos(ctx context.Conte
 			TalosVersion:                   cb.Spec.Talos.Version,
 			InstallDisk:                    cb.Spec.Talos.InstallDisk,
 			Platform:                       r.getTalosPlatform(cb.Spec.Provider),
-			AllowSchedulingOnControlPlanes: cb.IsSingleNode(), // Enable for single-node
+			AllowSchedulingOnControlPlanes: cb.IsSingleNode() || cb.Spec.Cluster.Workers == nil || cb.Spec.Cluster.Workers.Replicas == 0,
 		}
 
 		if cb.IsSingleNode() {
 			logger.Info("Single-node mode: enabling workload scheduling on control planes")
+		} else if cb.Spec.Cluster.Workers == nil || cb.Spec.Cluster.Workers.Replicas == 0 {
+			logger.Info("No workers configured: enabling workload scheduling on control planes")
 		}
 
 		// Convert config patches


### PR DESCRIPTION
## Summary

- Remove local `replace` directive for butler-api (use published v0.9.0)
- Remove stale butler-api COPY from Dockerfile
- Update default Steward chart version to 0.3.0
- Populate InstanceID on LoadBalancerRequest targets from MachineRequest status — fixes NLB target deregistration where all targets were classified as stale
- Allow scheduling on control planes when no workers are configured (extends existing single-node logic)

## Test plan

- [x] AWS single-node bootstrap E2E (verified)
- [x] AWS HA bootstrap E2E (3 CP + 2 workers) — all 5 nodes Ready, NLB healthy, all addons installed, zero manual intervention