### PR TITLE
feat: cloud console external access via CCM

### DIFF
--- a/internal/addons/azure_lb.go
+++ b/internal/addons/azure_lb.go
@@ -1,0 +1,326 @@
+/*
+Copyright 2026 The Butler Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package addons
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os/exec"
+	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const azureAPIVersion = "2023-09-01"
+
+// EnsureCloudLBBackendPool ensures management cluster nodes are in the cloud
+// LB backend pool. Only Azure requires this — Azure CCM v1.31 with
+// vmType=standard creates the LB but does not auto-populate the backend pool.
+func (i *Installer) EnsureCloudLBBackendPool(ctx context.Context, kubeconfig []byte, provider string, creds *ProviderCredentials, clusterName string) error {
+	if provider != "azure" {
+		return nil
+	}
+	if creds == nil || creds.Azure == nil {
+		return fmt.Errorf("Azure credentials required for LB backend pool setup")
+	}
+
+	kubeconfigPath, cleanup, err := i.writeKubeconfig(kubeconfig)
+	if err != nil {
+		return fmt.Errorf("failed to write kubeconfig: %w", err)
+	}
+	defer cleanup()
+
+	return i.ensureAzureLBBackendPool(ctx, kubeconfigPath, creds.Azure, clusterName)
+}
+
+// ensureAzureLBBackendPool adds management cluster node NICs to the Azure LB
+// backend pool using the Azure REST API directly (no SDK dependency).
+//
+// Azure CCM v1.31 with vmType=standard creates the LB rules, public IP, and
+// security group entries for LoadBalancer services, but its service controller
+// never triggers a backend pool sync after the initial startup. The backend
+// pool remains empty, making the LB unreachable.
+func (i *Installer) ensureAzureLBBackendPool(ctx context.Context, kubeconfigPath string, creds *AzureCredentials, clusterName string) error {
+	logger := log.FromContext(ctx)
+
+	token, err := getAzureToken(ctx, creds.TenantID, creds.ClientID, creds.ClientSecret)
+	if err != nil {
+		return fmt.Errorf("failed to get Azure token: %w", err)
+	}
+
+	// Azure CCM names the LB and backend pool after the cluster name.
+	lbName := clusterName
+	backendPoolName := clusterName
+
+	baseURL := fmt.Sprintf("https://management.azure.com/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network",
+		creds.SubscriptionID, creds.ResourceGroup)
+
+	// Get LB to find backend pool ID
+	lbURL := fmt.Sprintf("%s/loadBalancers/%s?api-version=%s", baseURL, lbName, azureAPIVersion)
+	lbBody, err := azureGET(ctx, lbURL, token)
+	if err != nil {
+		return fmt.Errorf("failed to get LB %s: %w", lbName, err)
+	}
+
+	var lb map[string]interface{}
+	if err := json.Unmarshal(lbBody, &lb); err != nil {
+		return fmt.Errorf("failed to parse LB response: %w", err)
+	}
+
+	backendPoolID, err := findBackendPoolID(lb, backendPoolName)
+	if err != nil {
+		return err
+	}
+
+	logger.Info("Found Azure LB backend pool", "lb", lbName, "pool", backendPoolName)
+
+	// List nodes via kubectl to get node names
+	nodeNames, err := i.listNodeNames(ctx, kubeconfigPath)
+	if err != nil {
+		return fmt.Errorf("failed to list nodes: %w", err)
+	}
+
+	for _, nodeName := range nodeNames {
+		nicName := fmt.Sprintf("%s-nic", nodeName)
+		nicURL := fmt.Sprintf("%s/networkInterfaces/%s?api-version=%s", baseURL, nicName, azureAPIVersion)
+
+		nicBody, err := azureGET(ctx, nicURL, token)
+		if err != nil {
+			logger.Error(err, "Failed to get NIC, skipping", "nic", nicName)
+			continue
+		}
+
+		var nic map[string]interface{}
+		if err := json.Unmarshal(nicBody, &nic); err != nil {
+			logger.Error(err, "Failed to parse NIC response", "nic", nicName)
+			continue
+		}
+
+		added, err := addBackendPoolToNIC(nic, backendPoolID)
+		if err != nil {
+			logger.Error(err, "Failed to modify NIC config", "nic", nicName)
+			continue
+		}
+		if !added {
+			logger.Info("NIC already in backend pool", "nic", nicName)
+			continue
+		}
+
+		updatedNIC, err := json.Marshal(nic)
+		if err != nil {
+			return fmt.Errorf("failed to marshal updated NIC: %w", err)
+		}
+
+		if err := azurePUT(ctx, nicURL, token, updatedNIC); err != nil {
+			return fmt.Errorf("failed to update NIC %s: %w", nicName, err)
+		}
+
+		logger.Info("Added NIC to LB backend pool", "nic", nicName, "pool", backendPoolName)
+	}
+
+	return nil
+}
+
+func (i *Installer) listNodeNames(ctx context.Context, kubeconfigPath string) ([]string, error) {
+	args := []string{
+		"--kubeconfig", kubeconfigPath,
+		"--insecure-skip-tls-verify",
+		"get", "nodes",
+		"-o", `jsonpath={range .items[*]}{.metadata.name}{"\n"}{end}`,
+	}
+	if i.NodeIP != "" {
+		args = append(args, "--server", fmt.Sprintf("https://%s:6443", i.NodeIP))
+	}
+	cmd := exec.CommandContext(ctx, i.KubectlPath, args...)
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+
+	var names []string
+	for _, name := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+	return names, nil
+}
+
+// findBackendPoolID navigates the LB JSON to find the backend pool ID by name.
+func findBackendPoolID(lb map[string]interface{}, poolName string) (string, error) {
+	props, ok := lb["properties"].(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("LB has no properties")
+	}
+	pools, ok := props["backendAddressPools"].([]interface{})
+	if !ok {
+		return "", fmt.Errorf("LB has no backendAddressPools")
+	}
+	for _, p := range pools {
+		pool, ok := p.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name, _ := pool["name"].(string)
+		id, _ := pool["id"].(string)
+		if name == poolName && id != "" {
+			return id, nil
+		}
+	}
+	return "", fmt.Errorf("backend pool %q not found on LB", poolName)
+}
+
+// addBackendPoolToNIC adds the backend pool reference to the NIC's first IP
+// config. Returns true if the pool was added, false if already present.
+func addBackendPoolToNIC(nic map[string]interface{}, backendPoolID string) (bool, error) {
+	props, ok := nic["properties"].(map[string]interface{})
+	if !ok {
+		return false, fmt.Errorf("NIC has no properties")
+	}
+	ipConfigs, ok := props["ipConfigurations"].([]interface{})
+	if !ok || len(ipConfigs) == 0 {
+		return false, fmt.Errorf("NIC has no ipConfigurations")
+	}
+	ipConfig, ok := ipConfigs[0].(map[string]interface{})
+	if !ok {
+		return false, fmt.Errorf("ipConfigurations[0] is not an object")
+	}
+	ipConfigProps, ok := ipConfig["properties"].(map[string]interface{})
+	if !ok {
+		return false, fmt.Errorf("ipConfigurations[0] has no properties")
+	}
+
+	// Check existing pools
+	var pools []interface{}
+	if existing, ok := ipConfigProps["loadBalancerBackendAddressPools"].([]interface{}); ok {
+		pools = existing
+	}
+
+	for _, p := range pools {
+		pool, ok := p.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if id, _ := pool["id"].(string); id == backendPoolID {
+			return false, nil // already present
+		}
+	}
+
+	pools = append(pools, map[string]interface{}{"id": backendPoolID})
+	ipConfigProps["loadBalancerBackendAddressPools"] = pools
+	return true, nil
+}
+
+// getAzureToken gets an Azure AD access token using service principal credentials.
+func getAzureToken(ctx context.Context, tenantID, clientID, clientSecret string) (string, error) {
+	tokenURL := fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/token", tenantID)
+
+	data := url.Values{
+		"grant_type":    {"client_credentials"},
+		"client_id":     {clientID},
+		"client_secret": {clientSecret},
+		"scope":         {"https://management.azure.com/.default"},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", tokenURL, strings.NewReader(data.Encode()))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("token request failed (%s): %s", resp.Status, body)
+	}
+
+	var tokenResp struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return "", fmt.Errorf("failed to parse token response: %w", err)
+	}
+	if tokenResp.AccessToken == "" {
+		return "", fmt.Errorf("empty access token in response")
+	}
+
+	return tokenResp.AccessToken, nil
+}
+
+// azureGET performs an authenticated GET against the Azure Management API.
+func azureGET(ctx context.Context, url, token string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("Azure API %s: %s", resp.Status, body)
+	}
+
+	return body, nil
+}
+
+// azurePUT performs an authenticated PUT against the Azure Management API.
+func azurePUT(ctx context.Context, reqURL, token string, body []byte) error {
+	req, err := http.NewRequestWithContext(ctx, "PUT", reqURL, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("Azure API %s: %s", resp.Status, respBody)
+	}
+
+	return nil
+}

--- a/internal/addons/installer.go
+++ b/internal/addons/installer.go
@@ -647,7 +647,7 @@ func (i *Installer) InstallCloudControllerManager(ctx context.Context, kubeconfi
 	case "gcp":
 		return i.installGCPCCM(ctx, kubeconfigPath, clusterName, creds)
 	case "azure":
-		return i.installAzureCCM(ctx, kubeconfigPath)
+		return i.installAzureCCM(ctx, kubeconfigPath, clusterName, creds)
 	default:
 		logger.Info("No CCM needed for provider", "provider", provider)
 		return nil
@@ -819,17 +819,121 @@ spec:
 		"-n", "kube-system", "--timeout=5m")
 }
 
-func (i *Installer) installAzureCCM(ctx context.Context, kubeconfigPath string) error {
-	// Azure CCM implementation deferred. Same pattern as AWS: create
-	// azure.json Secret, pass via helm values.
-	_ = i.runHelm(ctx, kubeconfigPath, "repo", "add", "cloud-provider-azure",
-		"https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo")
-	_ = i.runHelm(ctx, kubeconfigPath, "repo", "update")
-	return i.runHelm(ctx, kubeconfigPath,
-		"upgrade", "--install", "cloud-controller-manager",
-		"cloud-provider-azure/cloud-controller-manager",
-		"--namespace", "kube-system",
-		"--wait", "--timeout", "5m")
+func (i *Installer) installAzureCCM(ctx context.Context, kubeconfigPath string, clusterName string, creds *ProviderCredentials) error {
+	logger := log.FromContext(ctx)
+	if creds == nil || creds.Azure == nil {
+		return fmt.Errorf("Azure credentials required for CCM installation")
+	}
+
+	az := creds.Azure
+
+	// azure.json cloud-config consumed by the CCM binary
+	azureJSON := fmt.Sprintf(`{
+  "cloud": "AzurePublicCloud",
+  "tenantId": "%s",
+  "subscriptionId": "%s",
+  "aadClientId": "%s",
+  "aadClientSecret": "%s",
+  "resourceGroup": "%s",
+  "location": "%s",
+  "vnetName": "%s",
+  "subnetName": "%s",
+  "loadBalancerSku": "Standard",
+  "useInstanceMetadata": true
+}`, az.TenantID, az.SubscriptionID, az.ClientID, az.ClientSecret,
+		az.ResourceGroup, az.Location, az.VNetName, az.SubnetName)
+
+	azureJSONB64 := base64.StdEncoding.EncodeToString([]byte(azureJSON))
+
+	// Deploy CCM via embedded manifests for full control over config
+	manifest := fmt.Sprintf(`---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: azure-cloud-config
+  namespace: kube-system
+type: Opaque
+data:
+  azure.json: %s
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:cloud-controller-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloud-controller-manager
+  namespace: kube-system
+  labels:
+    component: cloud-controller-manager
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      component: cloud-controller-manager
+  template:
+    metadata:
+      labels:
+        component: cloud-controller-manager
+    spec:
+      serviceAccountName: cloud-controller-manager
+      tolerations:
+      - operator: Exists
+      containers:
+      - name: cloud-controller-manager
+        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.31.0
+        command:
+        - /usr/local/bin/cloud-controller-manager
+        args:
+        - --cloud-provider=azure
+        - --cloud-config=/etc/kubernetes/azure.json
+        - --configure-cloud-routes=false
+        - --allocate-node-cidrs=false
+        - --controllers=*,-node-route-controller
+        - --cluster-name=%s
+        - --v=2
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: "4"
+            memory: 2Gi
+        volumeMounts:
+        - name: azure-config
+          mountPath: /etc/kubernetes/azure.json
+          subPath: azure.json
+          readOnly: true
+      volumes:
+      - name: azure-config
+        secret:
+          secretName: azure-cloud-config
+`, azureJSONB64, clusterName)
+
+	if err := i.applyManifest(ctx, kubeconfigPath, manifest, "ccm-azure"); err != nil {
+		return fmt.Errorf("failed to apply Azure CCM manifests: %w", err)
+	}
+	logger.Info("Azure CCM manifests applied")
+
+	// Wait for Deployment to roll out
+	return i.runKubectl(ctx, kubeconfigPath, "rollout", "status", "deployment/cloud-controller-manager",
+		"-n", "kube-system", "--timeout=5m")
 }
 
 // applyManifest writes a YAML manifest to a temp file and applies it via kubectl.

--- a/internal/addons/installer.go
+++ b/internal/addons/installer.go
@@ -776,7 +776,7 @@ func (i *Installer) InstallSteward(ctx context.Context, kubeconfig []byte, versi
 	defer cleanup()
 
 	if version == "" {
-		version = "0.1.0"
+		version = "0.3.0"
 	}
 
 	logger.Info("Installing Steward", "version", version)

--- a/internal/addons/installer.go
+++ b/internal/addons/installer.go
@@ -2114,6 +2114,13 @@ func (i *Installer) InstallConsole(ctx context.Context, kubeconfig []byte, spec 
 		}
 	}
 
+	// Cloud providers use LoadBalancer instead of ClusterIP. CCM (installed
+	// earlier in the addon sequence) provisions the cloud-native LB.
+	isCloud := provider == "aws" || provider == "gcp" || provider == "azure"
+	if isCloud {
+		values = append(values, "frontend.service.type=LoadBalancer")
+	}
+
 	// Build helm install args - USE OCI REGISTRY
 	args := []string{
 		"upgrade", "--install",
@@ -2132,6 +2139,18 @@ func (i *Installer) InstallConsole(ctx context.Context, kubeconfig []byte, spec 
 
 	if err := i.runHelm(ctx, kubeconfigPath, args...); err != nil {
 		return "", fmt.Errorf("failed to install butler-console: %w", err)
+	}
+
+	// AWS: annotate the frontend Service for NLB instead of the default CLB.
+	// Applied via kubectl because the butler-console chart does not template
+	// service annotations. CCM will reconcile the CLB to an NLB.
+	if provider == "aws" {
+		if err := i.runKubectl(ctx, kubeconfigPath, "annotate", "svc", "butler-console-frontend",
+			"-n", "butler-system",
+			"service.beta.kubernetes.io/aws-load-balancer-type=nlb",
+			"--overwrite"); err != nil {
+			logger.Error(err, "Failed to annotate console service for NLB, falling back to CLB")
+		}
 	}
 
 	// Wait for deployments

--- a/internal/addons/installer.go
+++ b/internal/addons/installer.go
@@ -830,6 +830,8 @@ func (i *Installer) installAzureCCM(ctx context.Context, kubeconfigPath string, 
 
 	// azure.json cloud-config consumed by the CCM binary.
 	// securityGroupName is required for CCM to manage NSG rules for LoadBalancer services.
+	// primaryAvailabilitySetName tells CCM which AvailabilitySet contains nodes for
+	// LB backend pool membership (VMs outside an AvailabilitySet are not added).
 	azureJSON := fmt.Sprintf(`{
   "cloud": "AzurePublicCloud",
   "tenantId": "%s",
@@ -841,10 +843,13 @@ func (i *Installer) installAzureCCM(ctx context.Context, kubeconfigPath string, 
   "vnetName": "%s",
   "subnetName": "%s",
   "securityGroupName": "%s",
+  "primaryAvailabilitySetName": "%s-avset",
+  "vmType": "standard",
   "loadBalancerSku": "Standard",
   "useInstanceMetadata": true
 }`, az.TenantID, az.SubscriptionID, az.ClientID, az.ClientSecret,
-		az.ResourceGroup, az.Location, az.VNetName, az.SubnetName, az.SecurityGroupName)
+		az.ResourceGroup, az.Location, az.VNetName, az.SubnetName, az.SecurityGroupName,
+		clusterName)
 
 	azureJSONB64 := base64.StdEncoding.EncodeToString([]byte(azureJSON))
 

--- a/internal/addons/installer.go
+++ b/internal/addons/installer.go
@@ -84,8 +84,7 @@ type ProxmoxCredentials struct {
 	Password string
 }
 
-// GCPCredentials contains GCP service account and infrastructure config
-// extracted from a ProviderConfig for use during bootstrap.
+// GCPCredentials contains GCP service account and infrastructure config.
 type GCPCredentials struct {
 	ServiceAccountKey string // JSON service account key
 	ProjectID         string
@@ -98,8 +97,7 @@ type GCPCredentials struct {
 	ImageFamily       string
 }
 
-// AWSCredentials contains IAM credentials and VPC config
-// extracted from a ProviderConfig for use during bootstrap.
+// AWSCredentials contains IAM credentials and VPC config.
 type AWSCredentials struct {
 	AccessKeyID     string
 	SecretAccessKey  string
@@ -109,8 +107,7 @@ type AWSCredentials struct {
 	SecurityGroupID  string
 }
 
-// AzureCredentials contains service principal credentials and resource group config
-// extracted from a ProviderConfig for use during bootstrap.
+// AzureCredentials contains Azure service principal and resource group config.
 type AzureCredentials struct {
 	ClientID       string
 	ClientSecret   string
@@ -149,8 +146,7 @@ func (i *Installer) writeKubeconfig(kubeconfig []byte) (string, func(), error) {
 	return f.Name(), func() { os.Remove(f.Name()) }, nil
 }
 
-// makeKubeconfigInsecure modifies a kubeconfig to skip TLS verification
-// This is needed because clusterctl doesn't properly handle self-signed CAs
+// makeKubeconfigInsecure modifies a kubeconfig to skip TLS verification.
 func makeKubeconfigInsecure(kubeconfig []byte) ([]byte, error) {
 	config, err := clientcmd.Load(kubeconfig)
 	if err != nil {
@@ -1095,8 +1091,7 @@ func (i *Installer) InstallButler(ctx context.Context, kubeconfig []byte) error 
 	return nil
 }
 
-// InstallButlerCRDs installs Butler platform CRDs via Helm chart and overlays
-// embedded CRDs to ensure cloud provider fields are present.
+// InstallButlerCRDs installs Butler platform CRDs via Helm chart, overlaying embedded CRDs.
 func (i *Installer) InstallButlerCRDs(ctx context.Context, kubeconfig []byte, version string) error {
 	logger := log.FromContext(ctx)
 	logger.Info("Installing Butler platform CRDs", "version", version)
@@ -1218,9 +1213,7 @@ func (i *Installer) waitForButlerCRDs(ctx context.Context, kubeconfigPath string
 	return nil
 }
 
-// applyEmbeddedCRDs applies the embedded CRD YAML files to the target cluster.
-// This overlays any fields that are present in the build but not yet released
-// in the butler-crds Helm chart (e.g., cloud provider fields on ProviderConfig).
+// applyEmbeddedCRDs applies embedded CRDs, overlaying fields ahead of chart releases.
 func (i *Installer) applyEmbeddedCRDs(ctx context.Context, kubeconfigPath string) error {
 	logger := log.FromContext(ctx)
 
@@ -1263,8 +1256,7 @@ func (i *Installer) applyEmbeddedCRDs(ctx context.Context, kubeconfigPath string
 	return nil
 }
 
-// InstallInitialProviderConfig creates the initial ProviderConfig CR and credentials secret
-// on the management cluster based on the provider used during bootstrap.
+// InstallInitialProviderConfig creates the initial ProviderConfig CR and credentials secret.
 func (i *Installer) InstallInitialProviderConfig(ctx context.Context, kubeconfig []byte, providerType string, creds *ProviderCredentials) error {
 	logger := log.FromContext(ctx)
 	logger.Info("Creating initial ProviderConfig", "provider", providerType)
@@ -1531,8 +1523,7 @@ spec:
 	return secretManifest, providerConfigManifest
 }
 
-// generateGCPProviderConfig returns the Secret and ProviderConfig manifests
-// for a GCP provider on the target management cluster.
+// generateGCPProviderConfig returns Secret and ProviderConfig manifests for GCP.
 func (i *Installer) generateGCPProviderConfig(creds *GCPCredentials) (string, string) {
 	secretManifest := fmt.Sprintf(`apiVersion: v1
 kind: Secret
@@ -1590,8 +1581,7 @@ spec:
 	return secretManifest, providerConfigManifest
 }
 
-// generateAWSProviderConfig returns the Secret and ProviderConfig manifests
-// for an AWS provider on the target management cluster.
+// generateAWSProviderConfig returns Secret and ProviderConfig manifests for AWS.
 func (i *Installer) generateAWSProviderConfig(creds *AWSCredentials) (string, string) {
 	secretManifest := fmt.Sprintf(`apiVersion: v1
 kind: Secret
@@ -1638,8 +1628,7 @@ spec:
 	return secretManifest, providerConfigManifest
 }
 
-// generateAzureProviderConfig returns the Secret and ProviderConfig manifests
-// for an Azure provider on the target management cluster.
+// generateAzureProviderConfig returns Secret and ProviderConfig manifests for Azure.
 func (i *Installer) generateAzureProviderConfig(creds *AzureCredentials) (string, string) {
 	secretManifest := fmt.Sprintf(`apiVersion: v1
 kind: Secret

--- a/internal/addons/installer.go
+++ b/internal/addons/installer.go
@@ -634,7 +634,7 @@ spec:
 }
 
 // InstallCloudControllerManager installs the cloud-specific CCM via Helm.
-func (i *Installer) InstallCloudControllerManager(ctx context.Context, kubeconfig []byte, provider string, creds *ProviderCredentials) error {
+func (i *Installer) InstallCloudControllerManager(ctx context.Context, kubeconfig []byte, provider string, clusterName string, creds *ProviderCredentials) error {
 	logger := log.FromContext(ctx)
 	kubeconfigPath, cleanup, err := i.writeKubeconfig(kubeconfig)
 	if err != nil {
@@ -649,7 +649,7 @@ func (i *Installer) InstallCloudControllerManager(ctx context.Context, kubeconfi
 	case "aws":
 		return i.installAWSCCM(ctx, kubeconfigPath, creds)
 	case "gcp":
-		return i.installGCPCCM(ctx, kubeconfigPath, creds)
+		return i.installGCPCCM(ctx, kubeconfigPath, clusterName, creds)
 	case "azure":
 		return i.installAzureCCM(ctx, kubeconfigPath)
 	default:
@@ -705,7 +705,7 @@ stringData:
 	)
 }
 
-func (i *Installer) installGCPCCM(ctx context.Context, kubeconfigPath string, creds *ProviderCredentials) error {
+func (i *Installer) installGCPCCM(ctx context.Context, kubeconfigPath string, clusterName string, creds *ProviderCredentials) error {
 	logger := log.FromContext(ctx)
 	if creds == nil || creds.GCP == nil {
 		return fmt.Errorf("GCP credentials required for CCM installation")
@@ -732,6 +732,7 @@ data:
     project-id = %s
     network-name = %s
     regional = true
+    node-tags = %s
 ---
 apiVersion: v1
 kind: Secret
@@ -789,6 +790,8 @@ spec:
         - --cloud-provider=gce
         - --cloud-config=/etc/kubernetes/cloud-config
         - --configure-cloud-routes=false
+        - --allocate-node-cidrs=false
+        - --controllers=*,-nodeipam
         - --v=2
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -808,7 +811,7 @@ spec:
       - name: gcp-creds
         secret:
           secretName: gcp-cloud-credentials
-`, creds.GCP.ProjectID, network, saKeyB64)
+`, creds.GCP.ProjectID, network, clusterName, saKeyB64)
 
 	if err := i.applyManifest(ctx, kubeconfigPath, manifest, "ccm-gcp"); err != nil {
 		return fmt.Errorf("failed to apply GCP CCM manifests: %w", err)

--- a/internal/addons/installer.go
+++ b/internal/addons/installer.go
@@ -711,72 +711,113 @@ func (i *Installer) installGCPCCM(ctx context.Context, kubeconfigPath string, cr
 		return fmt.Errorf("GCP credentials required for CCM installation")
 	}
 
-	// Create cloud-config ConfigMap
 	network := creds.GCP.Network
 	if network == "" {
 		network = "default"
 	}
-	cloudConfig := fmt.Sprintf(`[global]
-project-id = %s
-network-name = %s
-regional = true
-`, creds.GCP.ProjectID, network)
 
-	configMapManifest := fmt.Sprintf(`apiVersion: v1
+	// Encode SA key as base64 for Secret
+	saKeyB64 := base64.StdEncoding.EncodeToString([]byte(creds.GCP.ServiceAccountKey))
+
+	// Deploy CCM via embedded manifests (no upstream Helm chart exists)
+	manifest := fmt.Sprintf(`---
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: gcp-cloud-config
   namespace: kube-system
 data:
   cloud-config: |
-%s`, indentString(cloudConfig, "    "))
-
-	if err := i.applyManifest(ctx, kubeconfigPath, configMapManifest, "ccm-gcp-config"); err != nil {
-		return fmt.Errorf("failed to create GCP cloud-config ConfigMap: %w", err)
-	}
-
-	// Create service account key Secret
-	secretManifest := fmt.Sprintf(`apiVersion: v1
+    [global]
+    project-id = %s
+    network-name = %s
+    regional = true
+---
+apiVersion: v1
 kind: Secret
 metadata:
   name: gcp-cloud-credentials
   namespace: kube-system
 type: Opaque
-stringData:
-  key.json: '%s'
-`, strings.ReplaceAll(creds.GCP.ServiceAccountKey, "'", "''"))
+data:
+  key.json: %s
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:cloud-controller-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cloud-controller-manager
+  namespace: kube-system
+  labels:
+    component: cloud-controller-manager
+spec:
+  selector:
+    matchLabels:
+      component: cloud-controller-manager
+  template:
+    metadata:
+      labels:
+        component: cloud-controller-manager
+    spec:
+      serviceAccountName: cloud-controller-manager
+      tolerations:
+      - operator: Exists
+      containers:
+      - name: cloud-controller-manager
+        image: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v30.0.0
+        command:
+        - /cloud-controller-manager
+        args:
+        - --cloud-provider=gce
+        - --cloud-config=/etc/kubernetes/cloud-config
+        - --configure-cloud-routes=false
+        - --v=2
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/kubernetes/gcp/key.json
+        volumeMounts:
+        - name: cloud-config
+          mountPath: /etc/kubernetes/cloud-config
+          subPath: cloud-config
+          readOnly: true
+        - name: gcp-creds
+          mountPath: /etc/kubernetes/gcp
+          readOnly: true
+      volumes:
+      - name: cloud-config
+        configMap:
+          name: gcp-cloud-config
+      - name: gcp-creds
+        secret:
+          secretName: gcp-cloud-credentials
+`, creds.GCP.ProjectID, network, saKeyB64)
 
-	if err := i.applyManifest(ctx, kubeconfigPath, secretManifest, "ccm-gcp-secret"); err != nil {
-		return fmt.Errorf("failed to create GCP CCM credentials Secret: %w", err)
+	if err := i.applyManifest(ctx, kubeconfigPath, manifest, "ccm-gcp"); err != nil {
+		return fmt.Errorf("failed to apply GCP CCM manifests: %w", err)
 	}
-	logger.Info("Created GCP CCM credentials")
+	logger.Info("GCP CCM manifests applied")
 
-	_ = i.runHelm(ctx, kubeconfigPath, "repo", "add", "cloud-provider-gcp",
-		"https://kubernetes-sigs.github.io/cloud-provider-gcp")
-	_ = i.runHelm(ctx, kubeconfigPath, "repo", "update")
-
-	return i.runHelm(ctx, kubeconfigPath,
-		"upgrade", "--install", "cloud-controller-manager",
-		"cloud-provider-gcp/cloud-provider-gcp",
-		"--namespace", "kube-system",
-		"--set", "cloudConfigPath=/etc/kubernetes/cloud-config",
-		"--set", "extraVolumes[0].name=cloud-config",
-		"--set", "extraVolumes[0].configMap.name=gcp-cloud-config",
-		"--set", "extraVolumeMounts[0].name=cloud-config",
-		"--set", "extraVolumeMounts[0].mountPath=/etc/kubernetes/cloud-config",
-		"--set", "extraVolumeMounts[0].subPath=cloud-config",
-		"--set", "extraVolumeMounts[0].readOnly=true",
-		"--set", "extraVolumes[1].name=gcp-creds",
-		"--set", "extraVolumes[1].secret.secretName=gcp-cloud-credentials",
-		"--set", "extraVolumeMounts[1].name=gcp-creds",
-		"--set", "extraVolumeMounts[1].mountPath=/etc/kubernetes/gcp",
-		"--set", "extraVolumeMounts[1].readOnly=true",
-		"--set", "extraEnvVars[0].name=GOOGLE_APPLICATION_CREDENTIALS",
-		"--set", "extraEnvVars[0].value=/etc/kubernetes/gcp/key.json",
-		"--set", "nodeSelector=null",
-		"--set", "tolerations[0].operator=Exists",
-		"--wait", "--timeout", "5m",
-	)
+	// Wait for DaemonSet to roll out
+	return i.runKubectl(ctx, kubeconfigPath, "rollout", "status", "daemonset/cloud-controller-manager",
+		"-n", "kube-system", "--timeout=5m")
 }
 
 func (i *Installer) installAzureCCM(ctx context.Context, kubeconfigPath string) error {
@@ -790,17 +831,6 @@ func (i *Installer) installAzureCCM(ctx context.Context, kubeconfigPath string) 
 		"cloud-provider-azure/cloud-controller-manager",
 		"--namespace", "kube-system",
 		"--wait", "--timeout", "5m")
-}
-
-// indentString indents each line of s with the given prefix.
-func indentString(s, prefix string) string {
-	lines := strings.Split(s, "\n")
-	for i, line := range lines {
-		if line != "" {
-			lines[i] = prefix + line
-		}
-	}
-	return strings.Join(lines, "\n")
 }
 
 // applyManifest writes a YAML manifest to a temp file and applies it via kubectl.

--- a/internal/addons/installer.go
+++ b/internal/addons/installer.go
@@ -703,6 +703,15 @@ stringData:
 		"--set", "env[1].valueFrom.secretKeyRef.name=aws-cloud-credentials",
 		"--set", "env[1].valueFrom.secretKeyRef.key=secret-access-key",
 		"--set", fmt.Sprintf("env[2].name=AWS_DEFAULT_REGION,env[2].value=%s", creds.AWS.Region),
+		// Override default args to disable cloud route management. The route
+		// controller requires a cluster CIDR (--cluster-cidr) and crashes without
+		// one. Management clusters use Cilium for pod networking, not cloud routes.
+		// All other controllers (service, cloud-node, cloud-node-lifecycle) run
+		// normally. cloud-node-controller is required to set spec.providerID on
+		// nodes, which the service controller needs for NLB target registration.
+		"--set", "args[0]=--v=2",
+		"--set", "args[1]=--cloud-provider=aws",
+		"--set", "args[2]=--configure-cloud-routes=false",
 		// Talos nodes may not have standard role labels. Clear nodeSelector
 		// to allow scheduling on any node, and tolerate all taints.
 		"--set", "nodeSelector=null",
@@ -751,6 +760,68 @@ func (i *Installer) applyManifest(ctx context.Context, kubeconfigPath string, ma
 	tmpFile.Close()
 
 	return i.runKubectl(ctx, kubeconfigPath, "apply", "-f", tmpFile.Name())
+}
+
+// SetNodeProviderIDs patches spec.providerID on management cluster nodes.
+// nodeProviderIDs maps private IP addresses to provider-format providerID strings
+// (e.g., "10.0.1.36" -> "aws:///us-east-1a/i-abc123"). The method lists nodes,
+// matches by InternalIP, and patches each node via kubectl.
+func (i *Installer) SetNodeProviderIDs(ctx context.Context, kubeconfig []byte, provider string, nodeProviderIDs map[string]string) error {
+	logger := log.FromContext(ctx)
+	kubeconfigPath, cleanup, err := i.writeKubeconfig(kubeconfig)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	if len(nodeProviderIDs) == 0 {
+		return nil
+	}
+
+	// Get all nodes with their InternalIPs via kubectl
+	args := []string{
+		"--kubeconfig", kubeconfigPath,
+		"--insecure-skip-tls-verify",
+		"get", "nodes",
+		"-o", `jsonpath={range .items[*]}{.metadata.name}{"\t"}{range .status.addresses[?(@.type=="InternalIP")]}{.address}{end}{"\n"}{end}`,
+	}
+	if i.NodeIP != "" {
+		args = append(args, "--server", fmt.Sprintf("https://%s:6443", i.NodeIP))
+	}
+	cmd := exec.CommandContext(ctx, i.KubectlPath, args...)
+	rawOutput, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("failed to list nodes: %w", err)
+	}
+	output := string(rawOutput)
+
+	// Parse node name -> internal IP
+	patched := 0
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		parts := strings.SplitN(line, "\t", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		nodeName := parts[0]
+		nodeIP := parts[1]
+
+		providerID, ok := nodeProviderIDs[nodeIP]
+		if !ok {
+			logger.Info("No providerID mapping for node", "node", nodeName, "ip", nodeIP)
+			continue
+		}
+
+		logger.Info("Setting providerID on node", "node", nodeName, "providerID", providerID)
+		patchJSON := fmt.Sprintf(`{"spec":{"providerID":"%s"}}`, providerID)
+		if err := i.runKubectl(ctx, kubeconfigPath, "patch", "node", nodeName,
+			"--type", "merge", "-p", patchJSON); err != nil {
+			return fmt.Errorf("failed to patch node %s providerID: %w", nodeName, err)
+		}
+		patched++
+	}
+
+	logger.Info("Node providerIDs patched", "patched", patched, "total", len(nodeProviderIDs))
+	return nil
 }
 
 // InstallTraefik installs Traefik ingress controller

--- a/internal/addons/installer.go
+++ b/internal/addons/installer.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	butlerv1alpha1 "github.com/butlerdotdev/butler-api/api/v1alpha1"
 	"github.com/butlerdotdev/butler-bootstrap/internal/crds"
@@ -2173,6 +2174,8 @@ func (i *Installer) InstallConsole(ctx context.Context, kubeconfig []byte, spec 
 }
 
 func (i *Installer) getConsoleURLFromSpec(ctx context.Context, kubeconfigPath string, spec *butlerv1alpha1.ConsoleAddonSpec, clusterName string, provider string) string {
+	logger := log.FromContext(ctx)
+
 	if spec != nil && spec.Ingress != nil && spec.Ingress.Enabled {
 		host := spec.Ingress.Host
 		if host == "" {
@@ -2185,17 +2188,57 @@ func (i *Installer) getConsoleURLFromSpec(ctx context.Context, kubeconfigPath st
 		return fmt.Sprintf("%s://%s", scheme, host)
 	}
 
-	// Try LoadBalancer IP
-	cmd := exec.CommandContext(ctx, i.KubectlPath,
+	// Cloud LoadBalancers take time to provision. Poll for up to 5 minutes.
+	// AWS returns a hostname; GCP and Azure return an IP.
+	isCloud := provider == "aws" || provider == "gcp" || provider == "azure"
+	if isCloud {
+		logger.Info("Waiting for cloud LoadBalancer endpoint")
+		for attempt := 0; attempt < 30; attempt++ {
+			if hostname, err := i.getServiceField(ctx, kubeconfigPath, "jsonpath={.status.loadBalancer.ingress[0].hostname}"); err != nil {
+				logger.Info("Error checking LB hostname, retrying", "error", err)
+			} else if hostname != "" {
+				logger.Info("Console LoadBalancer ready", "hostname", hostname)
+				return fmt.Sprintf("http://%s", hostname)
+			}
+
+			if ip, err := i.getServiceField(ctx, kubeconfigPath, "jsonpath={.status.loadBalancer.ingress[0].ip}"); err != nil {
+				logger.Info("Error checking LB IP, retrying", "error", err)
+			} else if ip != "" {
+				logger.Info("Console LoadBalancer ready", "ip", ip)
+				return fmt.Sprintf("http://%s", ip)
+			}
+
+			logger.Info("Waiting for console LoadBalancer", "attempt", attempt+1, "of", 30)
+			time.Sleep(10 * time.Second)
+		}
+		logger.Info("Console LoadBalancer not ready after 5 minutes, falling back to port-forward instructions")
+	}
+
+	// On-prem: try MetalLB-assigned LoadBalancer IP (single attempt)
+	if ip, err := i.getServiceField(ctx, kubeconfigPath, "jsonpath={.status.loadBalancer.ingress[0].ip}"); err == nil && ip != "" {
+		return fmt.Sprintf("http://%s", ip)
+	}
+
+	return "kubectl port-forward -n butler-system svc/butler-console-frontend 3000:80"
+}
+
+// getServiceField extracts a jsonpath field from the console frontend Service.
+// Returns ("", nil) if the field is empty/unset. Returns ("", err) on kubectl failure.
+func (i *Installer) getServiceField(ctx context.Context, kubeconfigPath string, jsonpath string) (string, error) {
+	args := []string{
 		"--kubeconfig", kubeconfigPath,
 		"--insecure-skip-tls-verify",
 		"get", "svc", "butler-console-frontend",
 		"-n", "butler-system",
-		"-o", "jsonpath={.status.loadBalancer.ingress[0].ip}",
-	)
-	if output, err := cmd.Output(); err == nil && len(output) > 0 {
-		return fmt.Sprintf("http://%s", string(output))
+		"-o", jsonpath,
 	}
-
-	return "kubectl port-forward -n butler-system svc/butler-console-frontend 3000:80"
+	if i.NodeIP != "" {
+		args = append(args, "--server", fmt.Sprintf("https://%s:6443", i.NodeIP))
+	}
+	cmd := exec.CommandContext(ctx, i.KubectlPath, args...)
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(output)), nil
 }

--- a/internal/addons/installer.go
+++ b/internal/addons/installer.go
@@ -634,7 +634,7 @@ spec:
 
 // InstallCloudControllerManager installs the cloud-specific CCM via Helm.
 // CCM is required for LoadBalancer services to get external IPs on cloud providers.
-func (i *Installer) InstallCloudControllerManager(ctx context.Context, kubeconfig []byte, provider string) error {
+func (i *Installer) InstallCloudControllerManager(ctx context.Context, kubeconfig []byte, provider string, creds *ProviderCredentials) error {
 	logger := log.FromContext(ctx)
 	kubeconfigPath, cleanup, err := i.writeKubeconfig(kubeconfig)
 	if err != nil {
@@ -1974,7 +1974,7 @@ spec:
 
 // InstallConsole installs butler-console (server + frontend) on the management cluster
 // Returns the console URL for user output
-func (i *Installer) InstallConsole(ctx context.Context, kubeconfig []byte, spec *butlerv1alpha1.ConsoleAddonSpec, clusterName string) (string, error) {
+func (i *Installer) InstallConsole(ctx context.Context, kubeconfig []byte, spec *butlerv1alpha1.ConsoleAddonSpec, clusterName string, provider string) (string, error) {
 	logger := log.FromContext(ctx)
 
 	version := "0.4.1"
@@ -2077,10 +2077,10 @@ func (i *Installer) InstallConsole(ctx context.Context, kubeconfig []byte, spec 
 	logger.Info("butler-console installed successfully")
 
 	// Determine URL
-	return i.getConsoleURLFromSpec(ctx, kubeconfigPath, spec, clusterName), nil
+	return i.getConsoleURLFromSpec(ctx, kubeconfigPath, spec, clusterName, provider), nil
 }
 
-func (i *Installer) getConsoleURLFromSpec(ctx context.Context, kubeconfigPath string, spec *butlerv1alpha1.ConsoleAddonSpec, clusterName string) string {
+func (i *Installer) getConsoleURLFromSpec(ctx context.Context, kubeconfigPath string, spec *butlerv1alpha1.ConsoleAddonSpec, clusterName string, provider string) string {
 	if spec != nil && spec.Ingress != nil && spec.Ingress.Enabled {
 		host := spec.Ingress.Host
 		if host == "" {

--- a/internal/addons/installer.go
+++ b/internal/addons/installer.go
@@ -634,12 +634,6 @@ spec:
 }
 
 // InstallCloudControllerManager installs the cloud-specific CCM via Helm.
-// CCM provides LoadBalancer service support by provisioning cloud-native load
-// balancers and managing associated security group / firewall rules.
-//
-// Management clusters run CCM in service-controller-only mode (no
-// --cloud-provider=external on kubelet). CCM handles LoadBalancer Services
-// but skips node lifecycle management, which Talos handles directly.
 func (i *Installer) InstallCloudControllerManager(ctx context.Context, kubeconfig []byte, provider string, creds *ProviderCredentials) error {
 	logger := log.FromContext(ctx)
 	kubeconfigPath, cleanup, err := i.writeKubeconfig(kubeconfig)
@@ -670,8 +664,6 @@ func (i *Installer) installAWSCCM(ctx context.Context, kubeconfigPath string, cr
 		return fmt.Errorf("AWS credentials required for CCM installation")
 	}
 
-	// Create credential Secret in kube-system on the management cluster.
-	// The CCM helm chart references this Secret for AWS API access.
 	secretManifest := fmt.Sprintf(`apiVersion: v1
 kind: Secret
 metadata:
@@ -703,17 +695,10 @@ stringData:
 		"--set", "env[1].valueFrom.secretKeyRef.name=aws-cloud-credentials",
 		"--set", "env[1].valueFrom.secretKeyRef.key=secret-access-key",
 		"--set", fmt.Sprintf("env[2].name=AWS_DEFAULT_REGION,env[2].value=%s", creds.AWS.Region),
-		// Override default args to disable cloud route management. The route
-		// controller requires a cluster CIDR (--cluster-cidr) and crashes without
-		// one. Management clusters use Cilium for pod networking, not cloud routes.
-		// All other controllers (service, cloud-node, cloud-node-lifecycle) run
-		// normally. cloud-node-controller is required to set spec.providerID on
-		// nodes, which the service controller needs for NLB target registration.
+		// Disable route controller (requires --cluster-cidr; Cilium handles pod networking)
 		"--set", "args[0]=--v=2",
 		"--set", "args[1]=--cloud-provider=aws",
 		"--set", "args[2]=--configure-cloud-routes=false",
-		// Talos nodes may not have standard role labels. Clear nodeSelector
-		// to allow scheduling on any node, and tolerate all taints.
 		"--set", "nodeSelector=null",
 		"--set", "tolerations[0].operator=Exists",
 		"--wait", "--timeout", "5m",
@@ -762,10 +747,8 @@ func (i *Installer) applyManifest(ctx context.Context, kubeconfigPath string, ma
 	return i.runKubectl(ctx, kubeconfigPath, "apply", "-f", tmpFile.Name())
 }
 
-// SetNodeProviderIDs patches spec.providerID on management cluster nodes.
-// nodeProviderIDs maps private IP addresses to provider-format providerID strings
-// (e.g., "10.0.1.36" -> "aws:///us-east-1a/i-abc123"). The method lists nodes,
-// matches by InternalIP, and patches each node via kubectl.
+// SetNodeProviderIDs patches spec.providerID on management cluster nodes by
+// matching InternalIP to the provided privateIP->providerID mapping.
 func (i *Installer) SetNodeProviderIDs(ctx context.Context, kubeconfig []byte, provider string, nodeProviderIDs map[string]string) (int, error) {
 	logger := log.FromContext(ctx)
 	kubeconfigPath, cleanup, err := i.writeKubeconfig(kubeconfig)
@@ -778,7 +761,6 @@ func (i *Installer) SetNodeProviderIDs(ctx context.Context, kubeconfig []byte, p
 		return 0, nil
 	}
 
-	// Get all nodes with their InternalIPs via kubectl
 	args := []string{
 		"--kubeconfig", kubeconfigPath,
 		"--insecure-skip-tls-verify",
@@ -795,7 +777,6 @@ func (i *Installer) SetNodeProviderIDs(ctx context.Context, kubeconfig []byte, p
 	}
 	output := string(rawOutput)
 
-	// Parse node name -> internal IP
 	patched := 0
 	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
 		parts := strings.SplitN(line, "\t", 2)
@@ -2186,13 +2167,6 @@ func (i *Installer) InstallConsole(ctx context.Context, kubeconfig []byte, spec 
 		}
 	}
 
-	// Cloud providers use LoadBalancer instead of ClusterIP. CCM (installed
-	// earlier in the addon sequence) provisions the cloud-native LB.
-	isCloud := provider == "aws" || provider == "gcp" || provider == "azure"
-	if isCloud {
-		values = append(values, "frontend.service.type=LoadBalancer")
-	}
-
 	// Build helm install args - USE OCI REGISTRY
 	args := []string{
 		"upgrade", "--install",
@@ -2213,15 +2187,18 @@ func (i *Installer) InstallConsole(ctx context.Context, kubeconfig []byte, spec 
 		return "", fmt.Errorf("failed to install butler-console: %w", err)
 	}
 
-	// AWS: annotate the frontend Service for NLB instead of the default CLB.
-	// Applied via kubectl because the butler-console chart does not template
-	// service annotations. CCM will reconcile the CLB to an NLB.
-	if provider == "aws" {
-		if err := i.runKubectl(ctx, kubeconfigPath, "annotate", "svc", "butler-console-frontend",
-			"-n", "butler-system",
-			"service.beta.kubernetes.io/aws-load-balancer-type=nlb",
-			"--overwrite"); err != nil {
-			logger.Error(err, "Failed to annotate console service for NLB, falling back to CLB")
+	// Patch service to LoadBalancer with provider-specific annotations atomically.
+	// Helm installs as ClusterIP; we patch annotation + type together so CCM
+	// creates the correct LB type on first observation (no orphaned CLB).
+	isCloud := provider == "aws" || provider == "gcp" || provider == "azure"
+	if isCloud {
+		patch := `{"spec":{"type":"LoadBalancer"}`
+		if provider == "aws" {
+			patch = `{"metadata":{"annotations":{"service.beta.kubernetes.io/aws-load-balancer-type":"nlb"}},"spec":{"type":"LoadBalancer"}}`
+		}
+		if err := i.runKubectl(ctx, kubeconfigPath, "patch", "svc", "butler-console-frontend",
+			"-n", "butler-system", "--type", "merge", "-p", patch); err != nil {
+			logger.Error(err, "Failed to patch console service to LoadBalancer")
 		}
 	}
 
@@ -2259,8 +2236,7 @@ func (i *Installer) getConsoleURLFromSpec(ctx context.Context, kubeconfigPath st
 		return fmt.Sprintf("%s://%s", scheme, host)
 	}
 
-	// Cloud LoadBalancers take time to provision. Poll for up to 5 minutes.
-	// AWS returns a hostname; GCP and Azure return an IP.
+	// Poll for cloud LoadBalancer endpoint (up to 5 minutes)
 	isCloud := provider == "aws" || provider == "gcp" || provider == "azure"
 	if isCloud {
 		logger.Info("Waiting for cloud LoadBalancer endpoint")
@@ -2285,7 +2261,7 @@ func (i *Installer) getConsoleURLFromSpec(ctx context.Context, kubeconfigPath st
 		logger.Info("Console LoadBalancer not ready after 5 minutes, falling back to port-forward instructions")
 	}
 
-	// On-prem: try MetalLB-assigned LoadBalancer IP (single attempt)
+	// On-prem: check for MetalLB-assigned IP
 	if ip, err := i.getServiceField(ctx, kubeconfigPath, "jsonpath={.status.loadBalancer.ingress[0].ip}"); err == nil && ip != "" {
 		return fmt.Sprintf("http://%s", ip)
 	}
@@ -2294,7 +2270,6 @@ func (i *Installer) getConsoleURLFromSpec(ctx context.Context, kubeconfigPath st
 }
 
 // getServiceField extracts a jsonpath field from the console frontend Service.
-// Returns ("", nil) if the field is empty/unset. Returns ("", err) on kubectl failure.
 func (i *Installer) getServiceField(ctx context.Context, kubeconfigPath string, jsonpath string) (string, error) {
 	args := []string{
 		"--kubeconfig", kubeconfigPath,

--- a/internal/addons/installer.go
+++ b/internal/addons/installer.go
@@ -25,7 +25,6 @@ import (
 
 	butlerv1alpha1 "github.com/butlerdotdev/butler-api/api/v1alpha1"
 	"github.com/butlerdotdev/butler-bootstrap/internal/crds"
-	"github.com/go-logr/logr"
 
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -653,18 +652,19 @@ func (i *Installer) InstallCloudControllerManager(ctx context.Context, kubeconfi
 
 	switch provider {
 	case "aws":
-		return i.installAWSCCM(ctx, kubeconfigPath, creds, logger)
+		return i.installAWSCCM(ctx, kubeconfigPath, creds)
 	case "gcp":
-		return i.installGCPCCM(ctx, kubeconfigPath, creds, logger)
+		return i.installGCPCCM(ctx, kubeconfigPath)
 	case "azure":
-		return i.installAzureCCM(ctx, kubeconfigPath, creds, logger)
+		return i.installAzureCCM(ctx, kubeconfigPath)
 	default:
 		logger.Info("No CCM needed for provider", "provider", provider)
 		return nil
 	}
 }
 
-func (i *Installer) installAWSCCM(ctx context.Context, kubeconfigPath string, creds *ProviderCredentials, logger logr.Logger) error {
+func (i *Installer) installAWSCCM(ctx context.Context, kubeconfigPath string, creds *ProviderCredentials) error {
+	logger := log.FromContext(ctx)
 	if creds == nil || creds.AWS == nil {
 		return fmt.Errorf("AWS credentials required for CCM installation")
 	}
@@ -710,7 +710,7 @@ stringData:
 	)
 }
 
-func (i *Installer) installGCPCCM(ctx context.Context, kubeconfigPath string, creds *ProviderCredentials, logger logr.Logger) error {
+func (i *Installer) installGCPCCM(ctx context.Context, kubeconfigPath string) error {
 	// GCP CCM implementation deferred. Helm chart maturity is a risk;
 	// may need embedded manifest fallback. See plan for details.
 	_ = i.runHelm(ctx, kubeconfigPath, "repo", "add", "cloud-provider-gcp",
@@ -723,7 +723,7 @@ func (i *Installer) installGCPCCM(ctx context.Context, kubeconfigPath string, cr
 		"--wait", "--timeout", "5m")
 }
 
-func (i *Installer) installAzureCCM(ctx context.Context, kubeconfigPath string, creds *ProviderCredentials, logger logr.Logger) error {
+func (i *Installer) installAzureCCM(ctx context.Context, kubeconfigPath string) error {
 	// Azure CCM implementation deferred. Same pattern as AWS: create
 	// azure.json Secret, pass via helm values.
 	_ = i.runHelm(ctx, kubeconfigPath, "repo", "add", "cloud-provider-azure",

--- a/internal/addons/installer.go
+++ b/internal/addons/installer.go
@@ -25,6 +25,7 @@ import (
 
 	butlerv1alpha1 "github.com/butlerdotdev/butler-api/api/v1alpha1"
 	"github.com/butlerdotdev/butler-bootstrap/internal/crds"
+	"github.com/go-logr/logr"
 
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -633,7 +634,12 @@ spec:
 }
 
 // InstallCloudControllerManager installs the cloud-specific CCM via Helm.
-// CCM is required for LoadBalancer services to get external IPs on cloud providers.
+// CCM provides LoadBalancer service support by provisioning cloud-native load
+// balancers and managing associated security group / firewall rules.
+//
+// Management clusters run CCM in service-controller-only mode (no
+// --cloud-provider=external on kubelet). CCM handles LoadBalancer Services
+// but skips node lifecycle management, which Talos handles directly.
 func (i *Installer) InstallCloudControllerManager(ctx context.Context, kubeconfig []byte, provider string, creds *ProviderCredentials) error {
 	logger := log.FromContext(ctx)
 	kubeconfigPath, cleanup, err := i.writeKubeconfig(kubeconfig)
@@ -646,37 +652,104 @@ func (i *Installer) InstallCloudControllerManager(ctx context.Context, kubeconfi
 	i.ensurePrivilegedNamespace(ctx, kubeconfigPath, "kube-system")
 
 	switch provider {
-	case "gcp":
-		_ = i.runHelm(ctx, kubeconfigPath, "repo", "add", "cloud-provider-gcp",
-			"https://kubernetes-sigs.github.io/cloud-provider-gcp")
-		_ = i.runHelm(ctx, kubeconfigPath, "repo", "update")
-		return i.runHelm(ctx, kubeconfigPath,
-			"upgrade", "--install", "cloud-controller-manager",
-			"cloud-provider-gcp/cloud-provider-gcp",
-			"--namespace", "kube-system",
-			"--wait", "--timeout", "5m")
 	case "aws":
-		_ = i.runHelm(ctx, kubeconfigPath, "repo", "add", "aws-cloud-controller-manager",
-			"https://kubernetes.github.io/cloud-provider-aws")
-		_ = i.runHelm(ctx, kubeconfigPath, "repo", "update")
-		return i.runHelm(ctx, kubeconfigPath,
-			"upgrade", "--install", "aws-cloud-controller-manager",
-			"aws-cloud-controller-manager/aws-cloud-controller-manager",
-			"--namespace", "kube-system",
-			"--wait", "--timeout", "5m")
+		return i.installAWSCCM(ctx, kubeconfigPath, creds, logger)
+	case "gcp":
+		return i.installGCPCCM(ctx, kubeconfigPath, creds, logger)
 	case "azure":
-		_ = i.runHelm(ctx, kubeconfigPath, "repo", "add", "cloud-provider-azure",
-			"https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo")
-		_ = i.runHelm(ctx, kubeconfigPath, "repo", "update")
-		return i.runHelm(ctx, kubeconfigPath,
-			"upgrade", "--install", "cloud-controller-manager",
-			"cloud-provider-azure/cloud-controller-manager",
-			"--namespace", "kube-system",
-			"--wait", "--timeout", "5m")
+		return i.installAzureCCM(ctx, kubeconfigPath, creds, logger)
 	default:
 		logger.Info("No CCM needed for provider", "provider", provider)
 		return nil
 	}
+}
+
+func (i *Installer) installAWSCCM(ctx context.Context, kubeconfigPath string, creds *ProviderCredentials, logger logr.Logger) error {
+	if creds == nil || creds.AWS == nil {
+		return fmt.Errorf("AWS credentials required for CCM installation")
+	}
+
+	// Create credential Secret in kube-system on the management cluster.
+	// The CCM helm chart references this Secret for AWS API access.
+	secretManifest := fmt.Sprintf(`apiVersion: v1
+kind: Secret
+metadata:
+  name: aws-cloud-credentials
+  namespace: kube-system
+type: Opaque
+stringData:
+  access-key-id: "%s"
+  secret-access-key: "%s"
+`, creds.AWS.AccessKeyID, creds.AWS.SecretAccessKey)
+
+	if err := i.applyManifest(ctx, kubeconfigPath, secretManifest, "ccm-aws-secret"); err != nil {
+		return fmt.Errorf("failed to create AWS CCM credentials Secret: %w", err)
+	}
+	logger.Info("Created AWS CCM credentials Secret")
+
+	_ = i.runHelm(ctx, kubeconfigPath, "repo", "add", "aws-cloud-controller-manager",
+		"https://kubernetes.github.io/cloud-provider-aws")
+	_ = i.runHelm(ctx, kubeconfigPath, "repo", "update")
+
+	return i.runHelm(ctx, kubeconfigPath,
+		"upgrade", "--install", "aws-cloud-controller-manager",
+		"aws-cloud-controller-manager/aws-cloud-controller-manager",
+		"--namespace", "kube-system",
+		"--set", "env[0].name=AWS_ACCESS_KEY_ID",
+		"--set", "env[0].valueFrom.secretKeyRef.name=aws-cloud-credentials",
+		"--set", "env[0].valueFrom.secretKeyRef.key=access-key-id",
+		"--set", "env[1].name=AWS_SECRET_ACCESS_KEY",
+		"--set", "env[1].valueFrom.secretKeyRef.name=aws-cloud-credentials",
+		"--set", "env[1].valueFrom.secretKeyRef.key=secret-access-key",
+		"--set", fmt.Sprintf("env[2].name=AWS_DEFAULT_REGION,env[2].value=%s", creds.AWS.Region),
+		// Talos nodes may not have standard role labels. Clear nodeSelector
+		// to allow scheduling on any node, and tolerate all taints.
+		"--set", "nodeSelector=null",
+		"--set", "tolerations[0].operator=Exists",
+		"--wait", "--timeout", "5m",
+	)
+}
+
+func (i *Installer) installGCPCCM(ctx context.Context, kubeconfigPath string, creds *ProviderCredentials, logger logr.Logger) error {
+	// GCP CCM implementation deferred. Helm chart maturity is a risk;
+	// may need embedded manifest fallback. See plan for details.
+	_ = i.runHelm(ctx, kubeconfigPath, "repo", "add", "cloud-provider-gcp",
+		"https://kubernetes-sigs.github.io/cloud-provider-gcp")
+	_ = i.runHelm(ctx, kubeconfigPath, "repo", "update")
+	return i.runHelm(ctx, kubeconfigPath,
+		"upgrade", "--install", "cloud-controller-manager",
+		"cloud-provider-gcp/cloud-provider-gcp",
+		"--namespace", "kube-system",
+		"--wait", "--timeout", "5m")
+}
+
+func (i *Installer) installAzureCCM(ctx context.Context, kubeconfigPath string, creds *ProviderCredentials, logger logr.Logger) error {
+	// Azure CCM implementation deferred. Same pattern as AWS: create
+	// azure.json Secret, pass via helm values.
+	_ = i.runHelm(ctx, kubeconfigPath, "repo", "add", "cloud-provider-azure",
+		"https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo")
+	_ = i.runHelm(ctx, kubeconfigPath, "repo", "update")
+	return i.runHelm(ctx, kubeconfigPath,
+		"upgrade", "--install", "cloud-controller-manager",
+		"cloud-provider-azure/cloud-controller-manager",
+		"--namespace", "kube-system",
+		"--wait", "--timeout", "5m")
+}
+
+// applyManifest writes a YAML manifest to a temp file and applies it via kubectl.
+func (i *Installer) applyManifest(ctx context.Context, kubeconfigPath string, manifest string, prefix string) error {
+	tmpFile, err := os.CreateTemp("", prefix+"-*.yaml")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if _, err := tmpFile.WriteString(manifest); err != nil {
+		return err
+	}
+	tmpFile.Close()
+
+	return i.runKubectl(ctx, kubeconfigPath, "apply", "-f", tmpFile.Name())
 }
 
 // InstallTraefik installs Traefik ingress controller

--- a/internal/addons/installer.go
+++ b/internal/addons/installer.go
@@ -109,14 +109,15 @@ type AWSCredentials struct {
 
 // AzureCredentials contains Azure service principal and resource group config.
 type AzureCredentials struct {
-	ClientID       string
-	ClientSecret   string
-	TenantID       string
-	SubscriptionID string
-	ResourceGroup  string
-	Location       string
-	VNetName       string
-	SubnetName     string
+	ClientID          string
+	ClientSecret      string
+	TenantID          string
+	SubscriptionID    string
+	ResourceGroup     string
+	Location          string
+	VNetName          string
+	SubnetName        string
+	SecurityGroupName string
 }
 
 // NewInstaller creates a new addon installer
@@ -827,7 +828,8 @@ func (i *Installer) installAzureCCM(ctx context.Context, kubeconfigPath string, 
 
 	az := creds.Azure
 
-	// azure.json cloud-config consumed by the CCM binary
+	// azure.json cloud-config consumed by the CCM binary.
+	// securityGroupName is required for CCM to manage NSG rules for LoadBalancer services.
 	azureJSON := fmt.Sprintf(`{
   "cloud": "AzurePublicCloud",
   "tenantId": "%s",
@@ -838,10 +840,11 @@ func (i *Installer) installAzureCCM(ctx context.Context, kubeconfigPath string, 
   "location": "%s",
   "vnetName": "%s",
   "subnetName": "%s",
+  "securityGroupName": "%s",
   "loadBalancerSku": "Standard",
   "useInstanceMetadata": true
 }`, az.TenantID, az.SubscriptionID, az.ClientID, az.ClientSecret,
-		az.ResourceGroup, az.Location, az.VNetName, az.SubnetName)
+		az.ResourceGroup, az.Location, az.VNetName, az.SubnetName, az.SecurityGroupName)
 
 	azureJSONB64 := base64.StdEncoding.EncodeToString([]byte(azureJSON))
 
@@ -1734,6 +1737,15 @@ spec:
 
 // generateAzureProviderConfig returns Secret and ProviderConfig manifests for Azure.
 func (i *Installer) generateAzureProviderConfig(creds *AzureCredentials) (string, string) {
+	secretData := fmt.Sprintf(`  clientID: "%s"
+  clientSecret: "%s"
+  tenantID: "%s"
+  subscriptionID: "%s"`, creds.ClientID, creds.ClientSecret, creds.TenantID, creds.SubscriptionID)
+	if creds.SecurityGroupName != "" {
+		secretData += fmt.Sprintf(`
+  securityGroupName: "%s"`, creds.SecurityGroupName)
+	}
+
 	secretManifest := fmt.Sprintf(`apiVersion: v1
 kind: Secret
 metadata:
@@ -1741,11 +1753,8 @@ metadata:
   namespace: butler-system
 type: Opaque
 stringData:
-  clientID: "%s"
-  clientSecret: "%s"
-  tenantID: "%s"
-  subscriptionID: "%s"
-`, creds.ClientID, creds.ClientSecret, creds.TenantID, creds.SubscriptionID)
+%s
+`, secretData)
 
 	azureConfig := fmt.Sprintf(`    subscriptionID: "%s"
     resourceGroup: "%s"`, creds.SubscriptionID, creds.ResourceGroup)

--- a/internal/addons/installer.go
+++ b/internal/addons/installer.go
@@ -649,7 +649,7 @@ func (i *Installer) InstallCloudControllerManager(ctx context.Context, kubeconfi
 	case "aws":
 		return i.installAWSCCM(ctx, kubeconfigPath, creds)
 	case "gcp":
-		return i.installGCPCCM(ctx, kubeconfigPath)
+		return i.installGCPCCM(ctx, kubeconfigPath, creds)
 	case "azure":
 		return i.installAzureCCM(ctx, kubeconfigPath)
 	default:
@@ -705,17 +705,78 @@ stringData:
 	)
 }
 
-func (i *Installer) installGCPCCM(ctx context.Context, kubeconfigPath string) error {
-	// GCP CCM implementation deferred. Helm chart maturity is a risk;
-	// may need embedded manifest fallback. See plan for details.
+func (i *Installer) installGCPCCM(ctx context.Context, kubeconfigPath string, creds *ProviderCredentials) error {
+	logger := log.FromContext(ctx)
+	if creds == nil || creds.GCP == nil {
+		return fmt.Errorf("GCP credentials required for CCM installation")
+	}
+
+	// Create cloud-config ConfigMap
+	network := creds.GCP.Network
+	if network == "" {
+		network = "default"
+	}
+	cloudConfig := fmt.Sprintf(`[global]
+project-id = %s
+network-name = %s
+regional = true
+`, creds.GCP.ProjectID, network)
+
+	configMapManifest := fmt.Sprintf(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gcp-cloud-config
+  namespace: kube-system
+data:
+  cloud-config: |
+%s`, indentString(cloudConfig, "    "))
+
+	if err := i.applyManifest(ctx, kubeconfigPath, configMapManifest, "ccm-gcp-config"); err != nil {
+		return fmt.Errorf("failed to create GCP cloud-config ConfigMap: %w", err)
+	}
+
+	// Create service account key Secret
+	secretManifest := fmt.Sprintf(`apiVersion: v1
+kind: Secret
+metadata:
+  name: gcp-cloud-credentials
+  namespace: kube-system
+type: Opaque
+stringData:
+  key.json: '%s'
+`, strings.ReplaceAll(creds.GCP.ServiceAccountKey, "'", "''"))
+
+	if err := i.applyManifest(ctx, kubeconfigPath, secretManifest, "ccm-gcp-secret"); err != nil {
+		return fmt.Errorf("failed to create GCP CCM credentials Secret: %w", err)
+	}
+	logger.Info("Created GCP CCM credentials")
+
 	_ = i.runHelm(ctx, kubeconfigPath, "repo", "add", "cloud-provider-gcp",
 		"https://kubernetes-sigs.github.io/cloud-provider-gcp")
 	_ = i.runHelm(ctx, kubeconfigPath, "repo", "update")
+
 	return i.runHelm(ctx, kubeconfigPath,
 		"upgrade", "--install", "cloud-controller-manager",
 		"cloud-provider-gcp/cloud-provider-gcp",
 		"--namespace", "kube-system",
-		"--wait", "--timeout", "5m")
+		"--set", "cloudConfigPath=/etc/kubernetes/cloud-config",
+		"--set", "extraVolumes[0].name=cloud-config",
+		"--set", "extraVolumes[0].configMap.name=gcp-cloud-config",
+		"--set", "extraVolumeMounts[0].name=cloud-config",
+		"--set", "extraVolumeMounts[0].mountPath=/etc/kubernetes/cloud-config",
+		"--set", "extraVolumeMounts[0].subPath=cloud-config",
+		"--set", "extraVolumeMounts[0].readOnly=true",
+		"--set", "extraVolumes[1].name=gcp-creds",
+		"--set", "extraVolumes[1].secret.secretName=gcp-cloud-credentials",
+		"--set", "extraVolumeMounts[1].name=gcp-creds",
+		"--set", "extraVolumeMounts[1].mountPath=/etc/kubernetes/gcp",
+		"--set", "extraVolumeMounts[1].readOnly=true",
+		"--set", "extraEnvVars[0].name=GOOGLE_APPLICATION_CREDENTIALS",
+		"--set", "extraEnvVars[0].value=/etc/kubernetes/gcp/key.json",
+		"--set", "nodeSelector=null",
+		"--set", "tolerations[0].operator=Exists",
+		"--wait", "--timeout", "5m",
+	)
 }
 
 func (i *Installer) installAzureCCM(ctx context.Context, kubeconfigPath string) error {
@@ -729,6 +790,17 @@ func (i *Installer) installAzureCCM(ctx context.Context, kubeconfigPath string) 
 		"cloud-provider-azure/cloud-controller-manager",
 		"--namespace", "kube-system",
 		"--wait", "--timeout", "5m")
+}
+
+// indentString indents each line of s with the given prefix.
+func indentString(s, prefix string) string {
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		if line != "" {
+			lines[i] = prefix + line
+		}
+	}
+	return strings.Join(lines, "\n")
 }
 
 // applyManifest writes a YAML manifest to a temp file and applies it via kubectl.

--- a/internal/addons/installer.go
+++ b/internal/addons/installer.go
@@ -766,16 +766,16 @@ func (i *Installer) applyManifest(ctx context.Context, kubeconfigPath string, ma
 // nodeProviderIDs maps private IP addresses to provider-format providerID strings
 // (e.g., "10.0.1.36" -> "aws:///us-east-1a/i-abc123"). The method lists nodes,
 // matches by InternalIP, and patches each node via kubectl.
-func (i *Installer) SetNodeProviderIDs(ctx context.Context, kubeconfig []byte, provider string, nodeProviderIDs map[string]string) error {
+func (i *Installer) SetNodeProviderIDs(ctx context.Context, kubeconfig []byte, provider string, nodeProviderIDs map[string]string) (int, error) {
 	logger := log.FromContext(ctx)
 	kubeconfigPath, cleanup, err := i.writeKubeconfig(kubeconfig)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	defer cleanup()
 
 	if len(nodeProviderIDs) == 0 {
-		return nil
+		return 0, nil
 	}
 
 	// Get all nodes with their InternalIPs via kubectl
@@ -791,7 +791,7 @@ func (i *Installer) SetNodeProviderIDs(ctx context.Context, kubeconfig []byte, p
 	cmd := exec.CommandContext(ctx, i.KubectlPath, args...)
 	rawOutput, err := cmd.Output()
 	if err != nil {
-		return fmt.Errorf("failed to list nodes: %w", err)
+		return 0, fmt.Errorf("failed to list nodes: %w", err)
 	}
 	output := string(rawOutput)
 
@@ -815,13 +815,13 @@ func (i *Installer) SetNodeProviderIDs(ctx context.Context, kubeconfig []byte, p
 		patchJSON := fmt.Sprintf(`{"spec":{"providerID":"%s"}}`, providerID)
 		if err := i.runKubectl(ctx, kubeconfigPath, "patch", "node", nodeName,
 			"--type", "merge", "-p", patchJSON); err != nil {
-			return fmt.Errorf("failed to patch node %s providerID: %w", nodeName, err)
+			return patched, fmt.Errorf("failed to patch node %s providerID: %w", nodeName, err)
 		}
 		patched++
 	}
 
 	logger.Info("Node providerIDs patched", "patched", patched, "total", len(nodeProviderIDs))
-	return nil
+	return patched, nil
 }
 
 // InstallTraefik installs Traefik ingress controller

--- a/internal/addons/installer.go
+++ b/internal/addons/installer.go
@@ -2297,7 +2297,7 @@ func (i *Installer) InstallConsole(ctx context.Context, kubeconfig []byte, spec 
 	// creates the correct LB type on first observation (no orphaned CLB).
 	isCloud := provider == "aws" || provider == "gcp" || provider == "azure"
 	if isCloud {
-		patch := `{"spec":{"type":"LoadBalancer"}`
+		patch := `{"spec":{"type":"LoadBalancer"}}`
 		if provider == "aws" {
 			patch = `{"metadata":{"annotations":{"service.beta.kubernetes.io/aws-load-balancer-type":"nlb"}},"spec":{"type":"LoadBalancer"}}`
 		}

--- a/internal/controller/clusterbootstrap_controller.go
+++ b/internal/controller/clusterbootstrap_controller.go
@@ -421,7 +421,7 @@ func (r *ClusterBootstrapReconciler) ensureMachineRequest(ctx context.Context, c
 			CPU:         pool.CPU,
 			MemoryMB:    pool.MemoryMB,
 			DiskGB:      pool.DiskGB,
-			Labels:      pool.Labels,
+			Labels:      r.buildMachineLabels(cb, pool.Labels),
 			Image:       imageOverride,
 		},
 	}
@@ -432,6 +432,21 @@ func (r *ClusterBootstrapReconciler) ensureMachineRequest(ctx context.Context, c
 
 	logger.Info("Created MachineRequest", "name", name, "role", role, "image", imageOverride)
 	return nil
+}
+
+// buildMachineLabels merges pool labels with cloud provider tags.
+// AWS CCM requires kubernetes.io/cluster/<name> tags on EC2 instances for
+// service controller instance discovery. The tag is injected here and flows
+// through to provider VM tags via MachineRequest.Spec.Labels.
+func (r *ClusterBootstrapReconciler) buildMachineLabels(cb *butlerv1alpha1.ClusterBootstrap, poolLabels map[string]string) map[string]string {
+	labels := make(map[string]string)
+	for k, v := range poolLabels {
+		labels[k] = v
+	}
+	if cb.IsCloudProvider() {
+		labels[fmt.Sprintf("kubernetes.io/cluster/%s", cb.Spec.Cluster.Name)] = "owned"
+	}
+	return labels
 }
 
 func (r *ClusterBootstrapReconciler) updateMachineStatuses(ctx context.Context, cb *butlerv1alpha1.ClusterBootstrap) error {

--- a/internal/controller/clusterbootstrap_controller.go
+++ b/internal/controller/clusterbootstrap_controller.go
@@ -835,14 +835,39 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 		}
 	}
 
-	// 2.5 Cloud Controller Manager - skipped for management cluster bootstrap.
-	// Management clusters don't need CCM. Setting --cloud-provider=external
-	// on kubelet adds an "uninitialized" taint that blocks all pod scheduling
-	// until CCM runs, creating a deadlock. Tenant clusters on cloud providers
-	// get CCM installed by butler-controller via CAPI machine templates.
+	// 2.5 Cloud Controller Manager -- provides LoadBalancer service support.
+	//
+	// Management clusters do NOT set --cloud-provider=external on kubelet.
+	// That flag adds a node.cloudprovider.kubernetes.io/uninitialized taint
+	// that blocks all pod scheduling until CCM removes it. Since CCM is
+	// itself a pod, this creates a scheduling deadlock.
+	//
+	// Without the flag, CCM runs in service-controller-only mode: it handles
+	// type:LoadBalancer Services (provisioning cloud LBs, managing security
+	// group rules) but skips node lifecycle (providerID, zone labels). Node
+	// lifecycle is unnecessary on management clusters where Talos manages
+	// nodes directly.
+	//
+	// Tenant clusters get --cloud-provider=external via CAPI machine
+	// templates, where CCM runs as a ManagementAddon with tolerations.
 	if cb.IsCloudProvider() {
-		r.ensureAddonsMap(cb)
-		cb.Status.AddonsInstalled["cloud-controller-manager"] = true
+		if !r.isAddonInstalled(cb, "cloud-controller-manager") {
+			logger.Info("Installing Cloud Controller Manager")
+			creds, err := r.getProviderCredentials(ctx, cb)
+			if err != nil {
+				logger.Error(err, "Failed to get provider credentials for CCM")
+				return ctrl.Result{RequeueAfter: requeueShort}, nil
+			}
+			if err := r.AddonInstaller.InstallCloudControllerManager(ctx, kubeconfig, cb.Spec.Provider, creds); err != nil {
+				logger.Error(err, "Failed to install Cloud Controller Manager")
+				return ctrl.Result{RequeueAfter: requeueShort}, nil
+			}
+			r.setAddonInstalled(cb, "cloud-controller-manager")
+			logger.Info("Cloud Controller Manager installed successfully")
+			if err := r.Status().Update(ctx, cb); err != nil {
+				logger.Error(err, "Failed to update status after CCM install")
+			}
+		}
 	}
 
 	// 3. cert-manager - needed by Traefik and Steward webhooks

--- a/internal/controller/clusterbootstrap_controller.go
+++ b/internal/controller/clusterbootstrap_controller.go
@@ -102,7 +102,7 @@ type AddonInstallerInterface interface {
 	InstallCertManager(ctx context.Context, kubeconfig []byte, version string) error
 	InstallLonghorn(ctx context.Context, kubeconfig []byte, version string, replicaCount int32) error
 	InstallMetalLB(ctx context.Context, kubeconfig []byte, addressPool string, topology string) error
-	InstallCloudControllerManager(ctx context.Context, kubeconfig []byte, provider string, creds *addons.ProviderCredentials) error
+	InstallCloudControllerManager(ctx context.Context, kubeconfig []byte, provider string, clusterName string, creds *addons.ProviderCredentials) error
 	InstallTraefik(ctx context.Context, kubeconfig []byte, version string) error
 	InstallGatewayAPI(ctx context.Context, kubeconfig []byte, version string) error
 	InstallSteward(ctx context.Context, kubeconfig []byte, version string) error
@@ -886,7 +886,7 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 				logger.Error(err, "Failed to get provider credentials for CCM")
 				return ctrl.Result{RequeueAfter: requeueShort}, nil
 			}
-			if err := r.AddonInstaller.InstallCloudControllerManager(ctx, kubeconfig, cb.Spec.Provider, creds); err != nil {
+			if err := r.AddonInstaller.InstallCloudControllerManager(ctx, kubeconfig, cb.Spec.Provider, cb.Spec.Cluster.Name, creds); err != nil {
 				logger.Error(err, "Failed to install Cloud Controller Manager")
 				return ctrl.Result{RequeueAfter: requeueShort}, nil
 			}

--- a/internal/controller/clusterbootstrap_controller.go
+++ b/internal/controller/clusterbootstrap_controller.go
@@ -914,7 +914,6 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 					return ctrl.Result{RequeueAfter: requeueShort}, nil
 				}
 			}
-			// Only mark complete when all expected nodes have been patched.
 			expectedNodes := int(cb.GetControlPlaneReplicas()) + int(cb.Spec.Cluster.Workers.Replicas)
 			if patchedCount >= expectedNodes {
 				r.setAddonInstalled(cb, "node-provider-ids")
@@ -958,8 +957,6 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 			logger.Info("Installing Longhorn")
 			version := addons.Storage.Version
 
-			// Use GetStorageReplicaCount() for topology-aware replica count
-			// Returns 1 for single-node, 3 for HA (default)
 			replicas := cb.GetStorageReplicaCount()
 
 			logger.Info("Installing Longhorn with replica count",

--- a/internal/controller/clusterbootstrap_controller.go
+++ b/internal/controller/clusterbootstrap_controller.go
@@ -481,11 +481,8 @@ func (r *ClusterBootstrapReconciler) buildNodeProviderIDMap(ctx context.Context,
 				result[privateIP] = fmt.Sprintf("aws:///%s", instanceID)
 			}
 		case "gcp":
-			if az != "" {
-				result[privateIP] = fmt.Sprintf("gce:///%s/%s", az, instanceID)
-			} else {
-				result[privateIP] = fmt.Sprintf("gce:///%s", instanceID)
-			}
+			// GCP provider stores full providerID: gce://<project>/<zone>/<name>
+			result[privateIP] = instanceID
 		case "azure":
 			result[privateIP] = fmt.Sprintf("azure:///%s", instanceID)
 		}

--- a/internal/controller/clusterbootstrap_controller.go
+++ b/internal/controller/clusterbootstrap_controller.go
@@ -915,7 +915,10 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 					return ctrl.Result{RequeueAfter: requeueShort}, nil
 				}
 			}
-			expectedNodes := int(cb.GetControlPlaneReplicas()) + int(cb.Spec.Cluster.Workers.Replicas)
+			expectedNodes := int(cb.GetControlPlaneReplicas())
+			if cb.Spec.Cluster.Workers != nil {
+				expectedNodes += int(cb.Spec.Cluster.Workers.Replicas)
+			}
 			if patchedCount >= expectedNodes {
 				r.setAddonInstalled(cb, "node-provider-ids")
 				logger.Info("All node providerIDs set", "count", len(nodeProviderIDs))

--- a/internal/controller/clusterbootstrap_controller.go
+++ b/internal/controller/clusterbootstrap_controller.go
@@ -435,10 +435,7 @@ func (r *ClusterBootstrapReconciler) ensureMachineRequest(ctx context.Context, c
 	return nil
 }
 
-// buildMachineLabels merges pool labels with cloud provider tags.
-// AWS CCM requires kubernetes.io/cluster/<name> tags on EC2 instances for
-// service controller instance discovery. The tag is injected here and flows
-// through to provider VM tags via MachineRequest.Spec.Labels.
+// buildMachineLabels merges pool labels with cloud-required instance tags.
 func (r *ClusterBootstrapReconciler) buildMachineLabels(cb *butlerv1alpha1.ClusterBootstrap, poolLabels map[string]string) map[string]string {
 	labels := make(map[string]string)
 	for k, v := range poolLabels {
@@ -450,9 +447,7 @@ func (r *ClusterBootstrapReconciler) buildMachineLabels(cb *butlerv1alpha1.Clust
 	return labels
 }
 
-// buildNodeProviderIDMap reads MachineRequests to build a mapping of private IP
-// to cloud providerID (e.g., "aws:///us-east-1a/i-abc123"). This mapping is used
-// to set spec.providerID on management cluster nodes so CCM can register NLB targets.
+// buildNodeProviderIDMap builds a privateIP->providerID mapping from MachineRequests.
 func (r *ClusterBootstrapReconciler) buildNodeProviderIDMap(ctx context.Context, cb *butlerv1alpha1.ClusterBootstrap) (map[string]string, error) {
 	machineRequests := &butlerv1alpha1.MachineRequestList{}
 	if err := r.List(ctx, machineRequests, client.InNamespace(cb.Namespace), client.MatchingLabels{
@@ -468,20 +463,18 @@ func (r *ClusterBootstrapReconciler) buildNodeProviderIDMap(ctx context.Context,
 			continue
 		}
 
-		// The first entry in IPAddresses is the private IP (set by the provider).
-		// We use this to match against node InternalIPs on the management cluster.
+		// IPAddresses[0] is the private IP (matches node InternalIP)
 		if len(mr.Status.IPAddresses) == 0 {
 			continue
 		}
 		privateIP := mr.Status.IPAddresses[0]
 
-		// Read AZ from provider annotation (set by butler-provider-aws)
+		// AZ from provider annotation
 		az := mr.Annotations["butler.butlerlabs.dev/availability-zone"]
 
-		// Build provider-specific providerID format
+		// Provider-specific providerID format
 		switch cb.Spec.Provider {
 		case "aws":
-			// AWS providerID format: aws:///<az>/<instance-id>
 			if az != "" {
 				result[privateIP] = fmt.Sprintf("aws:///%s/%s", az, instanceID)
 			} else {
@@ -886,20 +879,8 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 		}
 	}
 
-	// 2.5 Cloud Controller Manager -- provides LoadBalancer service support.
-	//
-	// Management clusters do NOT set --cloud-provider=external on kubelet.
-	// That flag adds a node.cloudprovider.kubernetes.io/uninitialized taint
-	// that blocks all pod scheduling until CCM removes it. Since CCM is
-	// itself a pod, this creates a scheduling deadlock.
-	//
-	// Without the flag, nodes lack spec.providerID. We set providerID
-	// explicitly (step 2.6) so CCM can register NLB/LB targets by instance.
-	// The route controller is disabled (--configure-cloud-routes=false)
-	// since Cilium handles pod networking.
-	//
-	// Tenant clusters get --cloud-provider=external via CAPI machine
-	// templates, where CCM runs as a ManagementAddon with tolerations.
+	// 2.5 Cloud Controller Manager (service-controller-only mode; see talos/client.go
+	// for why we don't set --cloud-provider=external on kubelet).
 	if cb.IsCloudProvider() {
 		if !r.isAddonInstalled(cb, "cloud-controller-manager") {
 			logger.Info("Installing Cloud Controller Manager")
@@ -919,13 +900,8 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 			}
 		}
 
-		// 2.6 Set spec.providerID on management cluster nodes.
-		// CCM needs providerID to register NLB targets. Since we do not set
-		// --cloud-provider=external on kubelet, nodes lack providerID by default.
-		// Build a mapping from private IP to AWS-format providerID using
-		// MachineRequest status (instance IDs + private IPs from IPAddresses).
-		// This step re-runs until all expected nodes are patched, since not all
-		// nodes may have joined the cluster when CCM is first installed.
+		// 2.6 Set spec.providerID on nodes (required for LB target registration).
+		// Re-runs until all expected nodes are patched.
 		if !r.isAddonInstalled(cb, "node-provider-ids") {
 			nodeProviderIDs, err := r.buildNodeProviderIDMap(ctx, cb)
 			if err != nil {

--- a/internal/controller/clusterbootstrap_controller.go
+++ b/internal/controller/clusterbootstrap_controller.go
@@ -1920,25 +1920,34 @@ func (r *ClusterBootstrapReconciler) updateLoadBalancerTargets(ctx context.Conte
 		if m.IPAddress == "" {
 			continue
 		}
-		targets = append(targets, butlerv1alpha1.LoadBalancerTarget{
+		target := butlerv1alpha1.LoadBalancerTarget{
 			IP:           m.IPAddress,
 			InstanceName: m.Name,
-		})
+		}
+		// Look up MachineRequest to get provider-specific instance ID
+		// (e.g., EC2 instance ID for AWS NLB target registration).
+		mr := &butlerv1alpha1.MachineRequest{}
+		if err := r.Get(ctx, client.ObjectKey{Name: m.Name, Namespace: cb.Namespace}, mr); err == nil {
+			if mr.Status.ProviderID != "" {
+				target.InstanceID = mr.Status.ProviderID
+			}
+		}
+		targets = append(targets, target)
 	}
 
 	if len(targets) == 0 {
 		return nil
 	}
 
-	// Only update if targets changed
+	// Only update if targets changed (check IP and InstanceID)
 	if len(targets) == len(lbr.Spec.Targets) {
 		changed := false
-		existing := make(map[string]bool)
+		existing := make(map[string]string) // IP -> InstanceID
 		for _, t := range lbr.Spec.Targets {
-			existing[t.IP] = true
+			existing[t.IP] = t.InstanceID
 		}
 		for _, t := range targets {
-			if !existing[t.IP] {
+			if existingID, ok := existing[t.IP]; !ok || existingID != t.InstanceID {
 				changed = true
 				break
 			}

--- a/internal/controller/clusterbootstrap_controller.go
+++ b/internal/controller/clusterbootstrap_controller.go
@@ -511,11 +511,13 @@ func (r *ClusterBootstrapReconciler) reconcileConfiguringTalos(ctx context.Conte
 			TalosVersion:                   cb.Spec.Talos.Version,
 			InstallDisk:                    cb.Spec.Talos.InstallDisk,
 			Platform:                       r.getTalosPlatform(cb.Spec.Provider),
-			AllowSchedulingOnControlPlanes: cb.IsSingleNode(), // Enable for single-node
+			AllowSchedulingOnControlPlanes: cb.IsSingleNode() || cb.Spec.Cluster.Workers == nil || cb.Spec.Cluster.Workers.Replicas == 0,
 		}
 
 		if cb.IsSingleNode() {
 			logger.Info("Single-node mode: enabling workload scheduling on control planes")
+		} else if cb.Spec.Cluster.Workers == nil || cb.Spec.Cluster.Workers.Replicas == 0 {
+			logger.Info("No workers configured: enabling workload scheduling on control planes")
 		}
 
 		// Convert config patches

--- a/internal/controller/clusterbootstrap_controller.go
+++ b/internal/controller/clusterbootstrap_controller.go
@@ -938,12 +938,12 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 	}
 
 	// 6. Traefik ingress - after MetalLB so it can get LoadBalancer IP.
-	// Cloud providers skip Traefik because there is no MetalLB or CCM to
-	// allocate LoadBalancer IPs on the management cluster. Traefik's LB
-	// Service stays <pending> and Helm --wait times out.
+	// Cloud providers skip Traefik. CCM provides LoadBalancer service
+	// support directly; the console gets its own cloud LB via CCM without
+	// needing an ingress controller as intermediary.
 	if !r.isAddonInstalled(cb, "traefik") {
 		if cb.IsCloudProvider() {
-			logger.Info("Skipping Traefik (cloud provider has no MetalLB/CCM for LoadBalancer)")
+			logger.Info("Skipping Traefik (cloud providers use CCM for LoadBalancer services)")
 		} else if addons.Ingress == nil || isAddonEnabled(addons.Ingress.Enabled) {
 			logger.Info("Installing Traefik")
 			version := ""

--- a/internal/controller/clusterbootstrap_controller.go
+++ b/internal/controller/clusterbootstrap_controller.go
@@ -114,6 +114,7 @@ type AddonInstallerInterface interface {
 	InstallButlerController(ctx context.Context, kubeconfig []byte, image string) error
 	InstallButlerAddons(ctx context.Context, kubeconfig []byte, version string) error
 	InstallConsole(ctx context.Context, kubeconfig []byte, spec *butlerv1alpha1.ConsoleAddonSpec, clusterName string, provider string) (string, error)
+	EnsureCloudLBBackendPool(ctx context.Context, kubeconfig []byte, provider string, creds *addons.ProviderCredentials, clusterName string) error
 	SetNodeProviderIDs(ctx context.Context, kubeconfig []byte, provider string, nodeProviderIDs map[string]string) (int, error)
 }
 
@@ -1244,6 +1245,28 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 			logger.Info("Butler Console installed successfully", "url", consoleURL)
 			if err := r.Status().Update(ctx, cb); err != nil {
 				logger.Error(err, "Failed to update status after Console install")
+			}
+		}
+	}
+
+	// 12.5 Ensure cloud LB backend pool is populated.
+	// Azure CCM v1.31 with vmType=standard does not auto-populate the backend
+	// pool, leaving the LB unreachable. Add node NICs to the pool directly.
+	if cb.IsCloudProvider() && string(cb.Spec.Provider) == "azure" {
+		if !r.isAddonInstalled(cb, "cloud-lb-backend-pool") {
+			creds, err := r.getProviderCredentials(ctx, cb)
+			if err != nil {
+				logger.Error(err, "Failed to get credentials for LB backend pool")
+				return ctrl.Result{RequeueAfter: requeueShort}, nil
+			}
+			if err := r.AddonInstaller.EnsureCloudLBBackendPool(ctx, kubeconfig, string(cb.Spec.Provider), creds, cb.Spec.Cluster.Name); err != nil {
+				logger.Error(err, "Failed to ensure cloud LB backend pool")
+				return ctrl.Result{RequeueAfter: requeueShort}, nil
+			}
+			r.setAddonInstalled(cb, "cloud-lb-backend-pool")
+			logger.Info("Cloud LB backend pool populated")
+			if err := r.Status().Update(ctx, cb); err != nil {
+				logger.Error(err, "Failed to update status after LB backend pool")
 			}
 		}
 	}

--- a/internal/controller/clusterbootstrap_controller.go
+++ b/internal/controller/clusterbootstrap_controller.go
@@ -102,7 +102,7 @@ type AddonInstallerInterface interface {
 	InstallCertManager(ctx context.Context, kubeconfig []byte, version string) error
 	InstallLonghorn(ctx context.Context, kubeconfig []byte, version string, replicaCount int32) error
 	InstallMetalLB(ctx context.Context, kubeconfig []byte, addressPool string, topology string) error
-	InstallCloudControllerManager(ctx context.Context, kubeconfig []byte, provider string) error
+	InstallCloudControllerManager(ctx context.Context, kubeconfig []byte, provider string, creds *addons.ProviderCredentials) error
 	InstallTraefik(ctx context.Context, kubeconfig []byte, version string) error
 	InstallGatewayAPI(ctx context.Context, kubeconfig []byte, version string) error
 	InstallSteward(ctx context.Context, kubeconfig []byte, version string) error
@@ -113,7 +113,7 @@ type AddonInstallerInterface interface {
 	InstallCAPI(ctx context.Context, kubeconfig []byte, version string, mgmtProvider string, additionalProviders []butlerv1alpha1.CAPIInfraProviderSpec, creds *addons.ProviderCredentials) error
 	InstallButlerController(ctx context.Context, kubeconfig []byte, image string) error
 	InstallButlerAddons(ctx context.Context, kubeconfig []byte, version string) error
-	InstallConsole(ctx context.Context, kubeconfig []byte, spec *butlerv1alpha1.ConsoleAddonSpec, clusterName string) (string, error)
+	InstallConsole(ctx context.Context, kubeconfig []byte, spec *butlerv1alpha1.ConsoleAddonSpec, clusterName string, provider string) (string, error)
 }
 
 // +kubebuilder:rbac:groups=butler.butlerlabs.dev,resources=clusterbootstraps,verbs=get;list;watch;create;update;patch;delete
@@ -1145,7 +1145,7 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 		if !r.isAddonInstalled(cb, "butler-console") {
 			logger.Info("Installing Butler Console")
 
-			consoleURL, err := r.AddonInstaller.InstallConsole(ctx, kubeconfig, addons.Console, cb.Spec.Cluster.Name)
+			consoleURL, err := r.AddonInstaller.InstallConsole(ctx, kubeconfig, addons.Console, cb.Spec.Cluster.Name, cb.Spec.Provider)
 			if err != nil {
 				logger.Error(err, "Failed to install Butler Console")
 				return ctrl.Result{RequeueAfter: requeueShort}, nil

--- a/internal/controller/clusterbootstrap_controller.go
+++ b/internal/controller/clusterbootstrap_controller.go
@@ -114,7 +114,7 @@ type AddonInstallerInterface interface {
 	InstallButlerController(ctx context.Context, kubeconfig []byte, image string) error
 	InstallButlerAddons(ctx context.Context, kubeconfig []byte, version string) error
 	InstallConsole(ctx context.Context, kubeconfig []byte, spec *butlerv1alpha1.ConsoleAddonSpec, clusterName string, provider string) (string, error)
-	SetNodeProviderIDs(ctx context.Context, kubeconfig []byte, provider string, nodeProviderIDs map[string]string) error
+	SetNodeProviderIDs(ctx context.Context, kubeconfig []byte, provider string, nodeProviderIDs map[string]string) (int, error)
 }
 
 // +kubebuilder:rbac:groups=butler.butlerlabs.dev,resources=clusterbootstraps,verbs=get;list;watch;create;update;patch;delete
@@ -924,22 +924,35 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 		// --cloud-provider=external on kubelet, nodes lack providerID by default.
 		// Build a mapping from private IP to AWS-format providerID using
 		// MachineRequest status (instance IDs + private IPs from IPAddresses).
+		// This step re-runs until all expected nodes are patched, since not all
+		// nodes may have joined the cluster when CCM is first installed.
 		if !r.isAddonInstalled(cb, "node-provider-ids") {
 			nodeProviderIDs, err := r.buildNodeProviderIDMap(ctx, cb)
 			if err != nil {
 				logger.Error(err, "Failed to build node providerID map")
 				return ctrl.Result{RequeueAfter: requeueShort}, nil
 			}
+			patchedCount := 0
 			if len(nodeProviderIDs) > 0 {
-				if err := r.AddonInstaller.SetNodeProviderIDs(ctx, kubeconfig, string(cb.Spec.Provider), nodeProviderIDs); err != nil {
-					logger.Error(err, "Failed to set node providerIDs")
+				var patchErr error
+				patchedCount, patchErr = r.AddonInstaller.SetNodeProviderIDs(ctx, kubeconfig, string(cb.Spec.Provider), nodeProviderIDs)
+				if patchErr != nil {
+					logger.Error(patchErr, "Failed to set node providerIDs")
 					return ctrl.Result{RequeueAfter: requeueShort}, nil
 				}
-				logger.Info("Node providerIDs set", "count", len(nodeProviderIDs))
 			}
-			r.setAddonInstalled(cb, "node-provider-ids")
-			if err := r.Status().Update(ctx, cb); err != nil {
-				logger.Error(err, "Failed to update status after setting providerIDs")
+			// Only mark complete when all expected nodes have been patched.
+			expectedNodes := int(cb.GetControlPlaneReplicas()) + int(cb.Spec.Cluster.Workers.Replicas)
+			if patchedCount >= expectedNodes {
+				r.setAddonInstalled(cb, "node-provider-ids")
+				logger.Info("All node providerIDs set", "count", len(nodeProviderIDs))
+				if err := r.Status().Update(ctx, cb); err != nil {
+					logger.Error(err, "Failed to update status after setting providerIDs")
+				}
+			} else {
+				logger.Info("Waiting for all nodes to join before completing providerID setup",
+					"patched", patchedCount, "expected", expectedNodes)
+				return ctrl.Result{RequeueAfter: requeueShort}, nil
 			}
 		}
 	}

--- a/internal/controller/clusterbootstrap_controller.go
+++ b/internal/controller/clusterbootstrap_controller.go
@@ -114,6 +114,7 @@ type AddonInstallerInterface interface {
 	InstallButlerController(ctx context.Context, kubeconfig []byte, image string) error
 	InstallButlerAddons(ctx context.Context, kubeconfig []byte, version string) error
 	InstallConsole(ctx context.Context, kubeconfig []byte, spec *butlerv1alpha1.ConsoleAddonSpec, clusterName string, provider string) (string, error)
+	SetNodeProviderIDs(ctx context.Context, kubeconfig []byte, provider string, nodeProviderIDs map[string]string) error
 }
 
 // +kubebuilder:rbac:groups=butler.butlerlabs.dev,resources=clusterbootstraps,verbs=get;list;watch;create;update;patch;delete
@@ -447,6 +448,56 @@ func (r *ClusterBootstrapReconciler) buildMachineLabels(cb *butlerv1alpha1.Clust
 		labels[fmt.Sprintf("kubernetes.io/cluster/%s", cb.Spec.Cluster.Name)] = "owned"
 	}
 	return labels
+}
+
+// buildNodeProviderIDMap reads MachineRequests to build a mapping of private IP
+// to cloud providerID (e.g., "aws:///us-east-1a/i-abc123"). This mapping is used
+// to set spec.providerID on management cluster nodes so CCM can register NLB targets.
+func (r *ClusterBootstrapReconciler) buildNodeProviderIDMap(ctx context.Context, cb *butlerv1alpha1.ClusterBootstrap) (map[string]string, error) {
+	machineRequests := &butlerv1alpha1.MachineRequestList{}
+	if err := r.List(ctx, machineRequests, client.InNamespace(cb.Namespace), client.MatchingLabels{
+		"butler.butlerlabs.dev/cluster-bootstrap": cb.Name,
+	}); err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]string)
+	for _, mr := range machineRequests.Items {
+		instanceID := mr.Status.ProviderID
+		if instanceID == "" {
+			continue
+		}
+
+		// The first entry in IPAddresses is the private IP (set by the provider).
+		// We use this to match against node InternalIPs on the management cluster.
+		if len(mr.Status.IPAddresses) == 0 {
+			continue
+		}
+		privateIP := mr.Status.IPAddresses[0]
+
+		// Read AZ from provider annotation (set by butler-provider-aws)
+		az := mr.Annotations["butler.butlerlabs.dev/availability-zone"]
+
+		// Build provider-specific providerID format
+		switch cb.Spec.Provider {
+		case "aws":
+			// AWS providerID format: aws:///<az>/<instance-id>
+			if az != "" {
+				result[privateIP] = fmt.Sprintf("aws:///%s/%s", az, instanceID)
+			} else {
+				result[privateIP] = fmt.Sprintf("aws:///%s", instanceID)
+			}
+		case "gcp":
+			if az != "" {
+				result[privateIP] = fmt.Sprintf("gce:///%s/%s", az, instanceID)
+			} else {
+				result[privateIP] = fmt.Sprintf("gce:///%s", instanceID)
+			}
+		case "azure":
+			result[privateIP] = fmt.Sprintf("azure:///%s", instanceID)
+		}
+	}
+	return result, nil
 }
 
 func (r *ClusterBootstrapReconciler) updateMachineStatuses(ctx context.Context, cb *butlerv1alpha1.ClusterBootstrap) error {
@@ -842,11 +893,10 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 	// that blocks all pod scheduling until CCM removes it. Since CCM is
 	// itself a pod, this creates a scheduling deadlock.
 	//
-	// Without the flag, CCM runs in service-controller-only mode: it handles
-	// type:LoadBalancer Services (provisioning cloud LBs, managing security
-	// group rules) but skips node lifecycle (providerID, zone labels). Node
-	// lifecycle is unnecessary on management clusters where Talos manages
-	// nodes directly.
+	// Without the flag, nodes lack spec.providerID. We set providerID
+	// explicitly (step 2.6) so CCM can register NLB/LB targets by instance.
+	// The route controller is disabled (--configure-cloud-routes=false)
+	// since Cilium handles pod networking.
 	//
 	// Tenant clusters get --cloud-provider=external via CAPI machine
 	// templates, where CCM runs as a ManagementAddon with tolerations.
@@ -866,6 +916,30 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 			logger.Info("Cloud Controller Manager installed successfully")
 			if err := r.Status().Update(ctx, cb); err != nil {
 				logger.Error(err, "Failed to update status after CCM install")
+			}
+		}
+
+		// 2.6 Set spec.providerID on management cluster nodes.
+		// CCM needs providerID to register NLB targets. Since we do not set
+		// --cloud-provider=external on kubelet, nodes lack providerID by default.
+		// Build a mapping from private IP to AWS-format providerID using
+		// MachineRequest status (instance IDs + private IPs from IPAddresses).
+		if !r.isAddonInstalled(cb, "node-provider-ids") {
+			nodeProviderIDs, err := r.buildNodeProviderIDMap(ctx, cb)
+			if err != nil {
+				logger.Error(err, "Failed to build node providerID map")
+				return ctrl.Result{RequeueAfter: requeueShort}, nil
+			}
+			if len(nodeProviderIDs) > 0 {
+				if err := r.AddonInstaller.SetNodeProviderIDs(ctx, kubeconfig, string(cb.Spec.Provider), nodeProviderIDs); err != nil {
+					logger.Error(err, "Failed to set node providerIDs")
+					return ctrl.Result{RequeueAfter: requeueShort}, nil
+				}
+				logger.Info("Node providerIDs set", "count", len(nodeProviderIDs))
+			}
+			r.setAddonInstalled(cb, "node-provider-ids")
+			if err := r.Status().Update(ctx, cb); err != nil {
+				logger.Error(err, "Failed to update status after setting providerIDs")
 			}
 		}
 	}

--- a/internal/controller/clusterbootstrap_controller.go
+++ b/internal/controller/clusterbootstrap_controller.go
@@ -484,7 +484,8 @@ func (r *ClusterBootstrapReconciler) buildNodeProviderIDMap(ctx context.Context,
 			// GCP provider stores full providerID: gce://<project>/<zone>/<name>
 			result[privateIP] = instanceID
 		case "azure":
-			result[privateIP] = fmt.Sprintf("azure:///%s", instanceID)
+			// ARM resource IDs start with /subscriptions/... so azure:// + /sub... = azure:///sub...
+			result[privateIP] = fmt.Sprintf("azure://%s", instanceID)
 		}
 	}
 	return result, nil

--- a/internal/controller/clusterbootstrap_controller.go
+++ b/internal/controller/clusterbootstrap_controller.go
@@ -1512,14 +1512,15 @@ func (r *ClusterBootstrapReconciler) getProviderCredentials(ctx context.Context,
 		logger.Info("Retrieved AWS credentials", "region", creds.AWS.Region)
 	case "azure":
 		creds.Azure = &addons.AzureCredentials{
-			ClientID:       string(secret.Data["clientID"]),
-			ClientSecret:   string(secret.Data["clientSecret"]),
-			TenantID:       string(secret.Data["tenantID"]),
-			SubscriptionID: string(secret.Data["subscriptionID"]),
-			ResourceGroup:  providerConfig.Spec.Azure.ResourceGroup,
-			Location:       providerConfig.Spec.Azure.Location,
-			VNetName:       providerConfig.Spec.Azure.VNetName,
-			SubnetName:     providerConfig.Spec.Azure.SubnetName,
+			ClientID:          string(secret.Data["clientID"]),
+			ClientSecret:      string(secret.Data["clientSecret"]),
+			TenantID:          string(secret.Data["tenantID"]),
+			SubscriptionID:    string(secret.Data["subscriptionID"]),
+			ResourceGroup:     providerConfig.Spec.Azure.ResourceGroup,
+			Location:          providerConfig.Spec.Azure.Location,
+			VNetName:          providerConfig.Spec.Azure.VNetName,
+			SubnetName:        providerConfig.Spec.Azure.SubnetName,
+			SecurityGroupName: string(secret.Data["securityGroupName"]),
 		}
 		logger.Info("Retrieved Azure credentials", "subscriptionID", creds.Azure.SubscriptionID, "resourceGroup", creds.Azure.ResourceGroup)
 	}
@@ -1639,14 +1640,15 @@ func (r *ClusterBootstrapReconciler) extractProviderCredentials(ctx context.Cont
 			return nil, fmt.Errorf("ProviderConfig %s has no azure configuration", providerConfigKey)
 		}
 		creds.Azure = &addons.AzureCredentials{
-			ClientID:       string(secret.Data["clientID"]),
-			ClientSecret:   string(secret.Data["clientSecret"]),
-			TenantID:       string(secret.Data["tenantID"]),
-			SubscriptionID: string(secret.Data["subscriptionID"]),
-			ResourceGroup:  providerConfig.Spec.Azure.ResourceGroup,
-			Location:       providerConfig.Spec.Azure.Location,
-			VNetName:       providerConfig.Spec.Azure.VNetName,
-			SubnetName:     providerConfig.Spec.Azure.SubnetName,
+			ClientID:          string(secret.Data["clientID"]),
+			ClientSecret:      string(secret.Data["clientSecret"]),
+			TenantID:          string(secret.Data["tenantID"]),
+			SubscriptionID:    string(secret.Data["subscriptionID"]),
+			ResourceGroup:     providerConfig.Spec.Azure.ResourceGroup,
+			Location:          providerConfig.Spec.Azure.Location,
+			VNetName:          providerConfig.Spec.Azure.VNetName,
+			SubnetName:        providerConfig.Spec.Azure.SubnetName,
+			SecurityGroupName: string(secret.Data["securityGroupName"]),
 		}
 		logger.Info("Extracted Azure credentials",
 			"subscriptionID", creds.Azure.SubscriptionID,

--- a/internal/crds/butler.butlerlabs.dev_providerconfigs.yaml
+++ b/internal/crds/butler.butlerlabs.dev_providerconfigs.yaml
@@ -93,6 +93,13 @@ spec:
                   Azure contains Azure-specific configuration.
                   Required when provider is "azure".
                 properties:
+                  imageURN:
+                    description: |-
+                      ImageURN is the VM image reference. Supports three formats:
+                      - URN: "publisher:offer:sku:version" (e.g., "Canonical:UbuntuServer:18.04-LTS:latest")
+                      - Managed image resource ID: "/subscriptions/.../images/my-image"
+                      - Shared gallery image ID: "/subscriptions/.../galleries/.../images/.../versions/..."
+                    type: string
                   location:
                     description: Location is the Azure region.
                     type: string
@@ -104,6 +111,9 @@ spec:
                     type: string
                   subscriptionID:
                     description: SubscriptionID is the Azure subscription ID.
+                    type: string
+                  vmSize:
+                    description: VMSize is the default Azure VM size (e.g., "Standard_D4s_v3").
                     type: string
                   vnetName:
                     description: VNetName is the Azure Virtual Network name.


### PR DESCRIPTION
## Summary

- Install Cloud Controller Manager (CCM) as a bootstrap addon for AWS, GCP, and Azure management clusters
- Deploy Butler Console as a LoadBalancer service, making it externally accessible without port-forward
- Set node providerIDs from MachineRequest metadata so CCM can register LB targets by instance
- Inject `kubernetes.io/cluster/<name>` tags into MachineRequest labels for CCM instance discovery
- Populate Azure LB backend pool via REST API (Azure CCM v1.31 backend sync bug workaround)

## Changes

- **CCM installation** (step 2.5): Provider-specific CCM deployment with credential Secrets
  - AWS: Helm chart with credential env vars and `--configure-cloud-routes=false`
  - GCP: Embedded DaemonSet manifest with cloud-config ConfigMap and SA key Secret
  - Azure: Embedded Deployment manifest with azure.json cloud-config, securityGroupName, primaryAvailabilitySetName, vmType=standard
- **Node providerID patching** (step 2.6): Builds privateIP->providerID mapping from MachineRequest status, patches nodes via kubectl, requeues until all nodes patched
- **Console LoadBalancer**: Helm installs as ClusterIP, then kubectl patches to LoadBalancer. AWS gets NLB annotation atomically to prevent orphaned CLBs
- **LB endpoint detection**: Polls for hostname (AWS) or IP (GCP/Azure) with 5-minute timeout
- **Azure LB backend pool** (step 12.5): Uses Azure REST API to add node NICs to LB backend pool after console install

## Test plan

- [x] Full E2E bootstrap on AWS (3 CP + 2 workers, HA topology)
- [x] Full E2E bootstrap on GCP (single-node topology)
- [x] Full E2E bootstrap on Azure (single-node topology)
- [x] CCM pods running, no CrashLoopBackOff on all three providers
- [x] Console accessible via cloud LB on all three providers (HTTP 200, no port-forward)
- [x] No orphaned CLBs on AWS (atomic annotation + type patch)
- [ ] On-prem regression (ClusterIP path unchanged)