### PR TITLE
fix: use validated LoadBalancerPool and harden bootstrap edge cases

### DIFF
--- a/internal/addons/installer.go
+++ b/internal/addons/installer.go
@@ -2316,7 +2316,7 @@ func (i *Installer) InstallConsole(ctx context.Context, kubeconfig []byte, spec 
 	logger := log.FromContext(ctx)
 
 	version := "0.4.1"
-	if spec != nil && spec.Version != "" {
+	if spec != nil && spec.Version != "" && !strings.EqualFold(spec.Version, "latest") {
 		version = spec.Version
 	}
 

--- a/internal/controller/clusterbootstrap_controller.go
+++ b/internal/controller/clusterbootstrap_controller.go
@@ -981,12 +981,13 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 		}
 	}
 
-	// 5. MetalLB
-	if addons.LoadBalancer != nil && addons.LoadBalancer.Type == "metallb" && addons.LoadBalancer.AddressPool != "" {
+	// 5. MetalLB — prefers network.loadBalancerPool over deprecated addons field
+	addressPool := cb.GetLoadBalancerAddressPool()
+	if addons.LoadBalancer != nil && addons.LoadBalancer.Type == "metallb" && addressPool != "" {
 		if !r.isAddonInstalled(cb, "metallb") {
-			logger.Info("Installing MetalLB")
+			logger.Info("Installing MetalLB", "addressPool", addressPool)
 
-			if err := r.AddonInstaller.InstallMetalLB(ctx, kubeconfig, addons.LoadBalancer.AddressPool, string(cb.Spec.Cluster.Topology)); err != nil {
+			if err := r.AddonInstaller.InstallMetalLB(ctx, kubeconfig, addressPool, string(cb.Spec.Cluster.Topology)); err != nil {
 				logger.Error(err, "Failed to install MetalLB")
 				return ctrl.Result{RequeueAfter: requeueShort}, nil
 			}
@@ -1814,7 +1815,9 @@ func (r *ClusterBootstrapReconciler) reconcileImageSync(ctx context.Context, cb 
 		bc := &butlerv1alpha1.ButlerConfig{}
 		if err := r.Get(ctx, client.ObjectKey{Name: "butler"}, bc); err != nil {
 			if errors.IsNotFound(err) {
-				return "", fmt.Errorf("schematicID %q is set but no ButlerConfig exists", schematicID)
+				// No ButlerConfig during bootstrap — skip image sync
+				logger.V(1).Info("No ButlerConfig found, skipping image sync", "schematicID", schematicID)
+				return "", nil
 			}
 			return "", fmt.Errorf("failed to get ButlerConfig: %w", err)
 		}


### PR DESCRIPTION
## Summary

- Use `GetLoadBalancerAddressPool()` helper for MetalLB installation, which prefers `network.loadBalancerPool` (validated) over the deprecated `addons.loadBalancer.addressPool`
- Skip image sync when no ButlerConfig exists (bootstrap context where image is specified via provider config)
- Treat console version "latest" as empty to use the hardcoded default version

## Context

The `GetLoadBalancerAddressPool()` helper was added to butler-api but never called. MetalLB installation was reading the deprecated `addressPool` field directly, bypassing IP validation and VIP overlap detection.

The image sync and console version fixes address edge cases hit during E2E testing across all providers.

## Test plan

- [x] E2E: Harvester single-node — MetalLB installed with pool from `network.loadBalancerPool`
- [x] E2E: Harvester HA — same
- [x] E2E: AWS/GCP/Azure — MetalLB skipped (no pool set), image sync skipped, console installs correctly