### PR TITLE
feat: install butler-controller via helm instead of kubectl apply

### DIFF
--- a/internal/addons/installer.go
+++ b/internal/addons/installer.go
@@ -2116,9 +2116,10 @@ func (i *Installer) getCAPINamespaces(ctx context.Context, kubeconfigPath string
 }
 
 // InstallButlerController installs butler-controller on the management cluster
-func (i *Installer) InstallButlerController(ctx context.Context, kubeconfig []byte, image string) error {
+// via the butler-controller Helm chart from the Butler OCI registry.
+func (i *Installer) InstallButlerController(ctx context.Context, kubeconfig []byte, image string, version string) error {
 	logger := log.FromContext(ctx)
-	logger.Info("Installing butler-controller", "image", image)
+	logger.Info("Installing butler-controller", "image", image, "chartVersion", version)
 
 	kubeconfigPath, cleanup, err := i.writeKubeconfig(kubeconfig)
 	if err != nil {
@@ -2126,188 +2127,60 @@ func (i *Installer) InstallButlerController(ctx context.Context, kubeconfig []by
 	}
 	defer cleanup()
 
-	// Ensure namespace exists first
 	if err := i.ensurePrivilegedNamespace(ctx, kubeconfigPath, "butler-system"); err != nil {
-		return fmt.Errorf("failed to create butler-system namespace: %w", err)
+		return fmt.Errorf("failed to prepare butler-system namespace: %w", err)
 	}
 
-	manifest := i.generateButlerControllerManifest(image)
-
-	tmpFile, err := os.CreateTemp("", "butler-controller-*.yaml")
-	if err != nil {
-		return err
-	}
-	defer os.Remove(tmpFile.Name())
-
-	if _, err := tmpFile.WriteString(manifest); err != nil {
-		return err
-	}
-	tmpFile.Close()
-
-	if err := i.runKubectl(ctx, kubeconfigPath, "apply", "-f", tmpFile.Name()); err != nil {
-		return fmt.Errorf("failed to apply butler-controller: %w", err)
+	if version == "" {
+		version = "0.12.0"
 	}
 
-	// Wait for deployment
+	repo, tag := splitImageRef(image)
+
 	args := []string{
-		"rollout", "status", "deployment", "butler-controller",
+		"upgrade", "--install",
+		"butler-controller",
+		"oci://ghcr.io/butlerdotdev/charts/butler-controller",
+		"--version", version,
 		"-n", "butler-system",
-		"--timeout=3m",
+		"--wait",
+		"--timeout", "5m",
+	}
+	if repo != "" {
+		args = append(args, "--set", "image.repository="+repo)
+	}
+	if tag != "" {
+		args = append(args, "--set", "image.tag="+tag)
 	}
 
-	if err := i.runKubectl(ctx, kubeconfigPath, args...); err != nil {
-		return fmt.Errorf("butler-controller not ready: %w", err)
+	if err := i.runHelm(ctx, kubeconfigPath, args...); err != nil {
+		return fmt.Errorf("failed to install butler-controller: %w", err)
 	}
 
 	logger.Info("butler-controller installed successfully")
 	return nil
 }
 
-// generateButlerControllerManifest generates the deployment manifest
-func (i *Installer) generateButlerControllerManifest(image string) string {
-	return fmt.Sprintf(`---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: butler-controller
-  namespace: butler-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: butler-controller-role
-rules:
-# Butler CRDs
-- apiGroups: ["butler.butlerlabs.dev"]
-  resources: ["*"]
-  verbs: ["*"]
-# CAPI resources
-- apiGroups: ["cluster.x-k8s.io"]
-  resources: ["*"]
-  verbs: ["*"]
-- apiGroups: ["infrastructure.cluster.x-k8s.io"]
-  resources: ["*"]
-  verbs: ["*"]
-- apiGroups: ["controlplane.cluster.x-k8s.io"]
-  resources: ["*"]
-  verbs: ["*"]
-- apiGroups: ["bootstrap.cluster.x-k8s.io"]
-  resources: ["*"]
-  verbs: ["*"]
-# Steward resources (hosted control planes)
-- apiGroups: ["steward.butlerlabs.dev"]
-  resources: ["*"]
-  verbs: ["*"]
-# Legacy Kamaji resources (for CAPI provider compatibility during transition)
-- apiGroups: ["kamaji.clastix.io"]
-  resources: ["*"]
-  verbs: ["*"]
-# Core resources - needed for Helm chart installs in ANY namespace
-- apiGroups: [""]
-  resources: ["*"]
-  verbs: ["*"]
-- apiGroups: ["apps"]
-  resources: ["*"]
-  verbs: ["*"]
-- apiGroups: ["batch"]
-  resources: ["*"]
-  verbs: ["*"]
-- apiGroups: ["rbac.authorization.k8s.io"]
-  resources: ["*"]
-  verbs: ["*"]
-- apiGroups: ["networking.k8s.io"]
-  resources: ["*"]
-  verbs: ["*"]
-- apiGroups: ["policy"]
-  resources: ["*"]
-  verbs: ["*"]
-- apiGroups: ["autoscaling"]
-  resources: ["*"]
-  verbs: ["*"]
-# Gateway API resources
-- apiGroups: ["gateway.networking.k8s.io"]
-  resources: ["*"]
-  verbs: ["*"]
-# Flux
-- apiGroups: ["helm.toolkit.fluxcd.io"]
-  resources: ["*"]
-  verbs: ["*"]
-- apiGroups: ["source.toolkit.fluxcd.io"]
-  resources: ["*"]
-  verbs: ["*"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: butler-controller-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: butler-controller-role
-subjects:
-- kind: ServiceAccount
-  name: butler-controller
-  namespace: butler-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: butler-controller-leader-election
-  namespace: butler-system
-rules:
-- apiGroups: ["coordination.k8s.io"]
-  resources: ["leases"]
-  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-- apiGroups: [""]
-  resources: ["events"]
-  verbs: ["create", "patch"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: butler-controller-leader-election
-  namespace: butler-system
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: butler-controller-leader-election
-subjects:
-- kind: ServiceAccount
-  name: butler-controller
-  namespace: butler-system
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: butler-controller
-  namespace: butler-system
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: butler-controller
-  template:
-    metadata:
-      labels:
-        app: butler-controller
-    spec:
-      serviceAccountName: butler-controller
-      containers:
-      - name: manager
-        image: %s
-        args:
-        - --leader-elect
-        ports:
-        - containerPort: 8080
-        - containerPort: 8081
-        resources:
-          limits:
-            cpu: 500m
-            memory: 256Mi
-          requests:
-            cpu: 100m
-            memory: 128Mi
-`, image)
+// splitImageRef splits a "repo:tag" image reference into its components.
+// It handles registries with ports (e.g. "registry.io:5000/repo:tag") by
+// splitting on the last colon after the last slash. Returns empty strings
+// for empty input, and ("ref", "") when the input has no tag separator.
+//
+// This function expects tag-based references. Digest-based references
+// (e.g. "repo@sha256:...") are not supported by this helper — bootstrap
+// constructs image strings via GetButlerControllerImage() which always
+// produces "repo:tag" form, so digest handling is unnecessary here.
+func splitImageRef(ref string) (string, string) {
+	if ref == "" {
+		return "", ""
+	}
+	slash := strings.LastIndex(ref, "/")
+	tail := ref[slash+1:]
+	colon := strings.LastIndex(tail, ":")
+	if colon < 0 {
+		return ref, ""
+	}
+	return ref[:slash+1+colon], tail[colon+1:]
 }
 
 // InstallConsole installs butler-console (server + frontend) on the management cluster

--- a/internal/addons/installer.go
+++ b/internal/addons/installer.go
@@ -2132,7 +2132,7 @@ func (i *Installer) InstallButlerController(ctx context.Context, kubeconfig []by
 	}
 
 	if version == "" {
-		version = "0.12.0"
+		version = "0.12.1"
 	}
 
 	repo, tag := splitImageRef(image)

--- a/internal/addons/installer_test.go
+++ b/internal/addons/installer_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package addons
+
+import "testing"
+
+func TestSplitImageRef(t *testing.T) {
+	cases := []struct {
+		name     string
+		ref      string
+		wantRepo string
+		wantTag  string
+	}{
+		{
+			name:     "empty",
+			ref:      "",
+			wantRepo: "",
+			wantTag:  "",
+		},
+		{
+			name:     "repo and tag only",
+			ref:      "repo:tag",
+			wantRepo: "repo",
+			wantTag:  "tag",
+		},
+		{
+			name:     "registry with repo and tag",
+			ref:      "registry.io/repo:tag",
+			wantRepo: "registry.io/repo",
+			wantTag:  "tag",
+		},
+		{
+			name:     "registry with port, repo, and tag",
+			ref:      "registry.io:5000/repo:tag",
+			wantRepo: "registry.io:5000/repo",
+			wantTag:  "tag",
+		},
+		{
+			name:     "no tag",
+			ref:      "registry.io/repo",
+			wantRepo: "registry.io/repo",
+			wantTag:  "",
+		},
+		{
+			// Digest references are not supported: splitImageRef splits on the
+			// last colon in the tail, which for a digest ref falls inside the
+			// digest itself. Callers must pass tag-based refs. Bootstrap's
+			// GetButlerControllerImage() always produces "repo:tag" form, so
+			// this case is a contract statement, not a supported input.
+			name:     "digest ref is not supported (documented)",
+			ref:      "ghcr.io/butlerdotdev/butler-controller@sha256:abc",
+			wantRepo: "ghcr.io/butlerdotdev/butler-controller@sha256",
+			wantTag:  "abc",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotRepo, gotTag := splitImageRef(tc.ref)
+			if gotRepo != tc.wantRepo || gotTag != tc.wantTag {
+				t.Errorf("splitImageRef(%q) = (%q, %q); want (%q, %q)",
+					tc.ref, gotRepo, gotTag, tc.wantRepo, tc.wantTag)
+			}
+		})
+	}
+}

--- a/internal/controller/clusterbootstrap_controller.go
+++ b/internal/controller/clusterbootstrap_controller.go
@@ -111,7 +111,7 @@ type AddonInstallerInterface interface {
 	InstallButlerCRDs(ctx context.Context, kubeconfig []byte, version string) error
 	InstallInitialProviderConfig(ctx context.Context, kubeconfig []byte, providerType string, creds *addons.ProviderCredentials) error
 	InstallCAPI(ctx context.Context, kubeconfig []byte, version string, mgmtProvider string, additionalProviders []butlerv1alpha1.CAPIInfraProviderSpec, creds *addons.ProviderCredentials) error
-	InstallButlerController(ctx context.Context, kubeconfig []byte, image string) error
+	InstallButlerController(ctx context.Context, kubeconfig []byte, image string, version string) error
 	InstallButlerAddons(ctx context.Context, kubeconfig []byte, version string) error
 	InstallConsole(ctx context.Context, kubeconfig []byte, spec *butlerv1alpha1.ConsoleAddonSpec, clusterName string, provider string) (string, error)
 	EnsureCloudLBBackendPool(ctx context.Context, kubeconfig []byte, provider string, creds *addons.ProviderCredentials, clusterName string) error
@@ -1175,7 +1175,7 @@ func (r *ClusterBootstrapReconciler) reconcileInstallingAddons(ctx context.Conte
 			image := addons.GetButlerControllerImage()
 			logger.Info("Installing Butler Controller", "image", image)
 
-			if err := r.AddonInstaller.InstallButlerController(ctx, kubeconfig, image); err != nil {
+			if err := r.AddonInstaller.InstallButlerController(ctx, kubeconfig, image, ""); err != nil {
 				logger.Error(err, "Failed to install Butler Controller")
 				return ctrl.Result{RequeueAfter: requeueShort}, nil
 			}


### PR DESCRIPTION
Closes #24.

## Summary

butler-controller was the last Butler component installed by bootstrap via raw `kubectl apply` of an inline manifest. Other components (butler-crds, butler-console, butler-addons) already install via `helm upgrade --install` from the `oci://ghcr.io/butlerdotdev/charts/*` registry. This change aligns butler-controller with the rest of the install flow.

`InstallButlerController` now invokes `helm upgrade --install butler-controller oci://ghcr.io/butlerdotdev/charts/butler-controller` with the existing `runHelm` helper, following the exact pattern used by `InstallButlerCRDs`. The 144-line inline YAML generator (`generateButlerControllerManifest`) and the temp-file + `kubectl apply` + `kubectl rollout status` plumbing are deleted.

## Why

- **GitOps export visibility** — butler-server discovers Helm releases by scanning `owner=helm,status=deployed` secrets. Without a Helm release secret, butler-controller was invisible to the Management GitOps tab.
- **Install consistency** — every other Butler component is a Helm release; butler-controller was the odd one out.
- **Webhook enablement path** — the chart has webhook infrastructure (ValidatingWebhookConfiguration, Certificate, self-signed ClusterIssuer) behind the `controller.webhooksEnabled` flag. Operators can now flip a values flag instead of migrating off raw manifests.

## Behavior changes

- **New clusters only.** Bootstrap runs on fresh management clusters — existing clusters (any already bootstrapped by prior versions) are untouched by this PR.
- **Webhook default stays OFF.** `controller.webhooksEnabled` is not set by bootstrap; chart default is `false`. Operators enable webhooks post-bootstrap by editing values. Backward-compatible with existing bootstrap behavior.
- **Chart version pinned to `0.12.0`** inside the installer. The new `version` parameter on `InstallButlerController(ctx, kubeconfig, image, version)` allows override, defaulting to `""` → `0.12.0`. Matches the `InstallButlerCRDs(ctx, kubeconfig, version)` shape.
- **Image plumbing preserved.** `GetButlerControllerImage()` still returns `"repo:tag"`. A new `splitImageRef` helper splits it into `image.repository` and `image.tag` `--set` flags, correctly handling registries with ports (`registry.io:5000/repo:tag`).
- **RBAC resource names drift** from the raw manifest (`butler-controller-role` → `butler-controller`, no separate leader-election Role/RoleBinding — chart consolidates coordination rules into the main ClusterRole). No collision risk because bootstrap only runs on fresh clusters.

## Test plan

- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./internal/addons/... -run TestSplitImageRef` — 6 cases pass (empty, `repo:tag`, `registry.io/repo:tag`, `registry.io:5000/repo:tag`, no-tag, digest ref documented as unsupported)
- [ ] Smoke test on KinD — helm install + release secret visibility check (see note below)

**Smoke test note:** envtest-based controller tests in `internal/controller/` require `/usr/local/kubebuilder/bin/etcd` which isn't available in the local dev environment. This is a pre-existing condition on `main`, unrelated to this PR. CI provides the kubebuilder assets. End-to-end bootstrap validation is gated on CI and the next customer bootstrap run.

## Files

- `internal/addons/installer.go` — rewrite `InstallButlerController`, add `splitImageRef`, delete `generateButlerControllerManifest`
- `internal/addons/installer_test.go` — new, covers `splitImageRef`
- `internal/controller/clusterbootstrap_controller.go` — update `AddonInstallerInterface` signature and call site to pass `version ""`