### PR TITLE
chore: bump default butler-controller chart to 0.12.2

### DIFF
--- a/internal/addons/installer.go
+++ b/internal/addons/installer.go
@@ -2132,7 +2132,7 @@ func (i *Installer) InstallButlerController(ctx context.Context, kubeconfig []by
 	}
 
 	if version == "" {
-		version = "0.12.1"
+		version = "0.12.2"
 	}
 
 	repo, tag := splitImageRef(image)


### PR DESCRIPTION
## Summary

- Bumps the default butler-controller chart version from 0.12.1 → 0.12.2 in `InstallButlerController()`
- Chart 0.12.2 adds `bind` verb on ClusterRoles needed for Team/TenantCluster RBAC reconciliation

## Dependencies

- Depends on butlerdotdev/butler-charts#68 being merged and the 0.12.2 OCI artifact published

## Test plan

- [ ] Verify 0.12.2 chart exists in OCI registry after charts PR merges
- [ ] Bootstrap a test cluster and confirm butler-controller installs with 0.12.2